### PR TITLE
Escape double-quotes in message strings

### DIFF
--- a/messageformat.js
+++ b/messageformat.js
@@ -63,10 +63,11 @@
     },
     escapeExpression : function (string) {
       var escape = {
-            "\n": "\\n"
+            "\n": "\\n",
+            "\"": '\\"'
           },
-          badChars = /(\n)|[\n]/g,
-          possible = /[\n]/,
+          badChars = /[\n"]/g,
+          possible = /[\n"]/,
           escapeChar = function(chr) {
             return escape[chr] || "&amp;";
           };
@@ -431,7 +432,7 @@
           }
           var result2 = result1 !== null
           ? (function(argIdx, efmt) {
-            var res = { 
+            var res = {
               type: "messageFormatElement",
               argumentIndex: argIdx
             };

--- a/test/tests.js
+++ b/test/tests.js
@@ -448,6 +448,11 @@ describe( "MessageFormat", function () {
         expect((mf.compile('中{test}中国话不用彁字。'))({test:"☺"})).to.eql( "中☺中国话不用彁字。" );
       });
 
+      it("escapes double quotes", function() {
+        var mf = new MessageFormat( 'en' );
+        expect((mf.compile('She said "Hello"'))()).to.eql('She said "Hello"');
+      });
+
       it("should get escaped brackets all the way out the other end", function () {
         var mf = new MessageFormat( 'en' );
         expect((mf.compile('\\{\\{\\{'))()).to.eql( "{{{" );


### PR DESCRIPTION
Double-quotes would cause problems when compiling the message to a function, as the code generation wraps strings in double-quotes.

I also removed `(\n)|` from the badChars regex, as I could not see why it was needed. Maybe I've missed something?
