### PR TITLE
Fail-safe for no translation

### DIFF
--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -184,6 +184,7 @@ function compiler(options, nm, obj){
     compiledMessageFormat = [options.namespace + '["' + nm + '"] = {}'];
 
   _(obj).forEach(function(value, key){
+    if (value == '') value = key;
     var str = mf.precompile( mf.parse(value) );
     compiledMessageFormat.push(options.namespace + '["' + nm + '"]["' + key + '"] = ' + str);
   });


### PR DESCRIPTION
This change simply passes through the original key in case there is no translation provided.

Before this change, if some text was untranslated, `{"Text goes here":""}` it would simply show up blank when used. This change makes it return the text in the original language, so the resulting UI is at least usable, albeit has elements displayed in the 'wrong' language.
