### PR TITLE
Add --combine option

### DIFF
--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -15,6 +15,7 @@ var nopt = require("nopt")
     "locale"    : String,
     "inputdir"  : Path,
     "output"    : Path,
+    "combine"   : String,
     "watch"     : Boolean,
     "namespace" : String,
     "include"   : String,
@@ -23,8 +24,9 @@ var nopt = require("nopt")
   },
   description = {
     "locale"    : "locale to use [mandatory]",
-    "inputdir"  : "directory containings messageformat files to compile",
+    "inputdir"  : "directory containing messageformat files to compile",
     "output"    : "output where messageformat will be compiled",
+    "combine"   : "combines multiple input files to the provided namespace array element",
     "watch"     : "watch `inputdir` for change",
     "namespace" : "object in the browser containing the templates",
     "include"   : "Glob patterns for files to include in `inputdir`",
@@ -34,6 +36,7 @@ var nopt = require("nopt")
   defaults = {
     "inputdir"  : process.cwd(),
     "output"    : process.cwd(),
+    "combine"   : undefined,
     "watch"     : false,
     "namespace" : 'window.i18n',
     "include"   : '**/*.json',
@@ -44,6 +47,7 @@ var nopt = require("nopt")
     "l"  : "--locale",
     "i"  : "--inputdir",
     "o"  : "--output",
+    "c"  : "--combine",
     "w"  : "--watch",
     "ns" : "--namespace",
     "I"  : "--include",
@@ -169,7 +173,14 @@ function build(inputdir, options, callback){
 
             var nm = join(file).split('.')[0].replace(/\\/g, '/'); // windows users should have the same key.
 
-            if( options.verbose ) console.log('Building ' + options.namespace + '["' + nm + '"]');
+            if(options.combine !== undefined) {
+              nm = options.combine;
+              if( options.verbose ) console.log('Adding to ' + options.namespace + '["' + nm + '"]');
+            }
+            else {
+              if( options.verbose ) console.log('Building ' + options.namespace + '["' + nm + '"]');
+            }
+
             compiledMessageFormat.push(compiler( options, nm, JSON.parse(text) ));
             cb();
           });


### PR DESCRIPTION
Alex, thanks for an awesome project!

From the CLI, I'd like the ability to control the output to the namespace array.  Currently, the namespace element is based on the file name.  If I have a folder structure like:

```
en
|-- one.json
|-- two.json
```

the resulting, generated namespace (i18n) array looks like:

``` javascript
window.i18n['one']
window.i18n['two']
```

I'd like the option to combine multiple files (recursively found) in a directory into a single namespace element per language.  The pull request implements this behavior by adding a **'-c'** or **'--combine'** option such as:

```
$ messageformat -l en -c en [input] [output]
```

At a higher level, I'm trying to achieve (using an AngularJS service and filter) a result similar to the link below but with multiple input files:

https://gist.github.com/iammerrick/5518936

What do you think?  Acceptable?

Thanks again!
