### PR TITLE
Add support for positional arguments

### DIFF
--- a/lib/message_parser.js
+++ b/lib/message_parser.js
@@ -872,13 +872,13 @@ module.exports = (function(){
         pos1 = pos;
         result0 = parse__();
         if (result0 !== null) {
-          if (/^[a-zA-Z$_]/.test(input.charAt(pos))) {
+          if (/^[0-9a-zA-Z$_]/.test(input.charAt(pos))) {
             result1 = input.charAt(pos);
             pos++;
           } else {
             result1 = null;
             if (reportFailures === 0) {
-              matchFailed("[a-zA-Z$_]");
+              matchFailed("[0-9a-zA-Z$_]");
             }
           }
           if (result1 !== null) {

--- a/lib/message_parser.pegjs
+++ b/lib/message_parser.pegjs
@@ -132,7 +132,7 @@ string
 // More or less, it has to be a single word
 // that doesn't contain punctuation, etc
 id
-  = _ s1:[a-zA-Z$_]s2:[^ \t\n\r,.+={}]* _ {
+  = _ s1:[0-9a-zA-Z$_]s2:[^ \t\n\r,.+={}]* _ {
     return s1 + (s2 ? s2.join('') : '');
   }
 

--- a/messageformat.js
+++ b/messageformat.js
@@ -993,13 +993,13 @@
           pos1 = pos;
           result0 = parse__();
           if (result0 !== null) {
-            if (/^[a-zA-Z$_]/.test(input.charAt(pos))) {
+            if (/^[0-9a-zA-Z$_]/.test(input.charAt(pos))) {
               result1 = input.charAt(pos);
               pos++;
             } else {
               result1 = null;
               if (reportFailures === 0) {
-                matchFailed("[a-zA-Z$_]");
+                matchFailed("[0-9a-zA-Z$_]");
               }
             }
             if (result1 !== null) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -74,6 +74,7 @@ describe( "MessageFormat", function () {
       it("should accept only a variable", function () {
         var mf = new MessageFormat( 'en' );
         expect( mf.parse('{test}') ).to.be.an( 'object' );
+        expect( mf.parse('{0}') ).to.be.an( 'object' );
       });
 
       it("should not care about white space in a variable", function () {
@@ -405,6 +406,11 @@ describe( "MessageFormat", function () {
         expect(function(){ mf.parse('{☺}'); }).to.throwError();
       });
 
+      it("should allow positional variables", function () {
+        var mf = new MessageFormat( 'en' );
+        expect(function(){ mf.parse('{0}'); }).to.not.throwError();
+      });
+
       it("should throw errors on negative offsets", function () {
         expect(function(){ mf.parse('{NUM, plural, offset:-4 other{a}}'); }).to.throwError();
       });
@@ -469,10 +475,20 @@ describe( "MessageFormat", function () {
         expect((mf.compile("The var is {VAR}."))({"VAR":5})).to.eql("The var is 5.");
       });
 
+      it("can substitute positional variables", function () {
+        var mf = new MessageFormat( 'en' );
+
+        expect((mf.compile("The var is {0}."))({"0":5})).to.eql("The var is 5.");
+        expect((mf.compile("The var is {0}."))([5])).to.eql("The var is 5.");
+        expect((mf.compile("The vars are {0} and {1}."))([5,-3])).to.eql("The vars are 5 and -3.");
+        expect((mf.compile("The vars are {0} and {01}."))([5,-3])).to.eql("The vars are 5 and undefined.");
+      });
+
       it("can substitute shorthand variables", function () {
         var mf = new MessageFormat( 'en' );
 
         expect((mf.compile("{VAR, select, other{The var is #.}}"))({"VAR":5})).to.eql("The var is 5.");
+        expect((mf.compile("{0, select, other{The var is #.}}"))([5])).to.eql("The var is 5.");
       });
 
       it("allows escaped shorthand variable: #", function () {


### PR DESCRIPTION
According to the [ICU MessageFormat spec](http://icu-project.org/apiref/icu4j/com/ibm/icu/text/MessageFormat.html), arguments should be either named or positional. At the moment, messageformat.js only supports named arguments. To get positional variables to also work, all we need to do is allow for the argument id to start with a digit. Then you can pass in an array rather than an object to the compiled function, and it'll just work.

This is valid because the variables are internally handled as strings, and JavaScript's conversion between numbers and their string representations matches that of the spec, such that `[3,5]["1"] == { "0":3, "1":5 }["1"] == 5` while `typeof [3,5]["01"] == "undefined"`. See the included new tests for example usage.
