### PR TITLE
Add support for empty string as select key

### DIFF
--- a/lib/message_parser.js
+++ b/lib/message_parser.js
@@ -778,6 +778,26 @@ module.exports = (function(){
           if (result0 === null) {
             pos = pos0;
           }
+          if (result0 === null) {
+            pos0 = pos;
+            if (input.substr(pos, 2) === "''") {
+              result0 = "''";
+              pos += 2;
+            } else {
+              result0 = null;
+              if (reportFailures === 0) {
+                matchFailed("\"''\"");
+              }
+            }
+            if (result0 !== null) {
+              result0 = (function(offset) {
+                return "";
+              })(pos0);
+            }
+            if (result0 === null) {
+              pos = pos0;
+            }
+          }
         }
         return result0;
       }

--- a/lib/message_parser.pegjs
+++ b/lib/message_parser.pegjs
@@ -112,6 +112,9 @@ stringKey
   / "=" d:digits {
     return d;
   }
+  / "''" {
+    return "";
+  }
 
 
 string

--- a/messageformat.js
+++ b/messageformat.js
@@ -904,6 +904,26 @@
             if (result0 === null) {
               pos = pos0;
             }
+            if (result0 === null) {
+              pos0 = pos;
+              if (input.substr(pos, 2) === "''") {
+                result0 = "''";
+                pos += 2;
+              } else {
+                result0 = null;
+                if (reportFailures === 0) {
+                  matchFailed("\"''\"");
+                }
+              }
+              if (result0 !== null) {
+                result0 = (function(offset) {
+                  return "";
+                })(pos0);
+              }
+              if (result0 === null) {
+                pos = pos0;
+              }
+            }
           }
           return result0;
         }

--- a/test/tests.js
+++ b/test/tests.js
@@ -163,6 +163,15 @@ describe( "MessageFormat", function () {
         expect(function(){ var a = mf.parse('{TEST, selecT, a{a} other{b}}'); }).to.throwError();
       });
 
+      it("should accept '' as a key value representing an empty string", function () {
+        var mf = new MessageFormat( 'en' );
+        expect(function(){ mf.parse("{VAR, select, ''{a} other{b}}"); }).to.not.throwError();
+        expect( mf.parse( "x {TEST, select, ''{a} other{b} }" )
+                    .program.statements[1].statements[0]
+                    .elementFormat.val.pluralForms[0].key
+              ).to.eql( '' );
+      });
+
     });
 
     describe( "Plurals", function () {
@@ -594,6 +603,16 @@ describe( "MessageFormat", function () {
         expect(function(){ var x = mfunc({FRIENDS:0}); }).to.throwError(/MessageFormat\: \`ENEMIES\` isnt a number\./);
         expect(function(){ var x = mfunc({}); }).to.throwError(/MessageFormat\: \`.+\` isnt a number\./);
         expect(function(){ var x = mfunc({ENEMIES:0}); }).to.throwError(/MessageFormat\: \`FRIENDS\` isnt a number\./);
+      });
+
+      it("should allow for a select with a case for an empty string", function () {
+        var mf = new MessageFormat( 'en' );
+        var mfunc = mf.compile("I am {FEELING, select, ''{happy} b{sad} other{indifferent}}.");
+
+        expect(mfunc({FEELING:""})).to.eql("I am happy.");
+        expect(mfunc({FEELING:"b"})).to.eql("I am sad.");
+        expect(mfunc({FEELING:"q"})).to.eql("I am indifferent.");
+        expect(mfunc({})).to.eql("I am indifferent.");
       });
     });
 


### PR DESCRIPTION
This makes the following work: `The key is {KEY, select, ''{missing!} other{this: {KEY}}}`

It adds `''` (two single quotes) as a special `stringKey` that matches an empty string. Included are two new tests that show how it works.

The particular expression that inspired this for me was the following, which required separately generating `GOT_*` booleans for each case:

```
Listing { N, plural, one { one item } other { # items } }
{ GOT_DAY, select, true { on {DAY} } other {} }
{ GOT_AREA, select, true { in {AREA} } other {} }
{ GOT_Q, select, true { matching the query {Q} } other {} }
```

which I could now rewrite as follows:

```
Listing { N, plural, one { one item} other { # items } }
{ DAY, select, ''{} other { on {DAY} } }
{ AREA, select, ''{} other { in {AREA} } }
{ Q, select, ''{} other { matching the query {Q} } }
```
