### PR TITLE
More nuanced pluralization for Icelandic

### DIFF
--- a/locale/is.js
+++ b/locale/is.js
@@ -1,1 +1,3 @@
-MessageFormat.locale.is=function(n){return n===1?"one":"other"}
+  MessageFormat.locale.is = function(n) {
+    return ((n%10) === 1 && (n%100) !== 11) ? 'one' : 'other';
+  };


### PR DESCRIPTION
When pluralizing in Icelandic words take singular form if the counter ends in 1, except for 11, e.g.:
1 hestur, 2 hestar, ..., 11 hestar, ..., 20 hestar, 21 hestur
unable to find a source for this online.
