### PR TITLE
Stop leaking things outside our own namespace

### DIFF
--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -129,78 +129,57 @@ function build(inputdir, options, callback){
   // arrays of compiled templates
   var compiledMessageFormat = [];
 
-  // read shared include file
-  var inclFile = join(__dirname, '..', 'lib', 'messageformat.include.js');
-  if(options.verbose) console.log('Load include file: ' + inclFile);
-  fs.readFile(inclFile, function(err, inclStr){
-    if(err) handleError(new Error('Could not read shared include file.' ));
+  var mf = new MessageFormat(options.locale, false, options.namespace.replace(/^window\./, ''));
 
-    // read locale file
-    var localeFile = join(__dirname, '..', 'locale', options.locale + '.js');
-    if(options.verbose) console.log('Load locale file: ' + localeFile);
-    fs.readFile(localeFile, function(err, localeStr){
-      if(err) handleError(new Error('locale ' + options.locale + ' not supported.' ));
-      var script = vm.createScript(localeStr);
-      // needed for runInThisContext
-      global.MessageFormat = MessageFormat;
-      script.runInThisContext();
+  if( options.verbose ) { console.log('Read dir: ' + inputdir); }
+  // list each file in inputdir folder and subfolders
+  glob(options.include, {cwd: inputdir}, function(err, files){
+    files = files.map(function(file){
+      // normalize the file name
+      return file.replace(inputdir, '').replace(/^\//, '');
+    })
 
-      if( options.verbose ) { console.log('Read dir: ' + inputdir); }
-      // list each file in inputdir folder and subfolders
-      glob(options.include, {cwd: inputdir}, function(err, files){
-        files = files.map(function(file){
-          // normalize the file name
-          return file.replace(inputdir, '').replace(/^\//, '');
-        })
-
-        async.forEach(files, readFile, function(err){
-          // errors are logged in readFile. No need to print them here.
-          var fileData = [
-            '(function(){ ' + options.namespace + ' || (' + options.namespace + ' = {}) ',
-            'var MessageFormat = { locale: {} };',
-            localeStr.toString().trim(),
-            inclStr.toString().trim(),
-          ].concat(compiledMessageFormat)
-          .concat(['})();']);
-          return callback(null, _.flatten(fileData));
-        });
-
-        // Read each file, compile them, and append the result in the `compiledI18n` array
-        function readFile(file, cb){
-          var path = join(inputdir, file);
-          fs.stat(path, function(err, stat){
-            if(err) { handleError(err); return  cb(); }
-            if(!stat.isFile()) {
-              if( options.verbose ) { handleError('Skip ' + file); }
-              return cb();
-            }
-
-            fs.readFile(path, 'utf8', function(err, text){
-              if(err) { handleError(err); return cb() }
-
-              var nm = join(file).split('.')[0].replace(/\\/g, '/'); // windows users should have the same key.
-
-              if(options.combine !== undefined) {
-                nm = options.combine;
-                if( options.verbose ) console.log('Adding to ' + options.namespace + '["' + nm + '"]');
-              }
-              else {
-                if( options.verbose ) console.log('Building ' + options.namespace + '["' + nm + '"]');
-              }
-
-              compiledMessageFormat.push(compiler( options, nm, JSON.parse(text) ));
-              cb();
-            });
-          });
-        }
-      });
+    async.forEach(files, readFile, function(err){
+      // errors are logged in readFile. No need to print them here.
+      var fileData = ['(function(G){G[\'' + mf.globalName + '\']=' + mf.functions()]
+        .concat(compiledMessageFormat)
+        .concat(['})(this);']);
+      return callback(null, _.flatten(fileData));
     });
+
+    // Read each file, compile them, and append the result in the `compiledI18n` array
+    function readFile(file, cb){
+      var path = join(inputdir, file);
+      fs.stat(path, function(err, stat){
+        if(err) { handleError(err); return  cb(); }
+        if(!stat.isFile()) {
+          if( options.verbose ) { handleError('Skip ' + file); }
+          return cb();
+        }
+
+        fs.readFile(path, 'utf8', function(err, text){
+          if(err) { handleError(err); return cb() }
+
+          var nm = join(file).split('.')[0].replace(/\\/g, '/'); // windows users should have the same key.
+
+          if(options.combine !== undefined) {
+            nm = options.combine;
+            if( options.verbose ) console.log('Adding to ' + mf.globalName + '["' + nm + '"]');
+          }
+          else {
+            if( options.verbose ) console.log('Building ' + mf.globalName + '["' + nm + '"]');
+          }
+
+          compiledMessageFormat.push(compiler( mf, nm, JSON.parse(text) ));
+          cb();
+        });
+      });
+    }
   });
 }
 
-function compiler(options, nm, obj){
-  var mf = new MessageFormat(options.locale),
-    cmf = [options.namespace + '["' + nm + '"] = {'];
+function compiler(mf, nm, obj){
+  var cmf = [mf.globalName + '["' + nm + '"] = {'];
 
   _(obj).forEach(function(value, key){
     var str = mf.precompile( mf.parse(value) );

--- a/example/en/i18n.js
+++ b/example/en/i18n.js
@@ -1,16 +1,13 @@
-(function(){ window.i18n || (window.i18n = {}) 
-var MessageFormat = { locale: {} };
-MessageFormat.locale.en=function(n){return n===1?"one":"other"}
-var
-c=function(d){if(!d)throw new Error("MessageFormat: No data passed to function.")},
-n=function(d,k,o){if(isNaN(d[k]))throw new Error("MessageFormat: `"+k+"` isnt a number.");return d[k]-(o||0)},
-v=function(d,k){c(d);return d[k]},
-p=function(d,k,o,l,p){c(d);return p[d[k]]||p[MessageFormat.locale[l](d[k]-o)]||p.other},
-s=function(d,k,p){c(d);return p[d[k]]||p.other};
-window.i18n["colors"] = {
+(function(G){G['i18n']={lc:{"en":function(n){return n===1?"one":"other"}},
+c:function(d,k){if(!d)throw new Error("MessageFormat: Data required for '"+k+"'.")},
+n:function(d,k,o){if(isNaN(d[k]))throw new Error("MessageFormat: '"+k+"' isn't a number.");return d[k]-(o||0)},
+v:function(d,k){i18n.c(d,k);return d[k]},
+p:function(d,k,o,l,p){i18n.c(d,k);return d[k] in p?p[d[k]]:(k=i18n.lc[l](d[k]-o),k in p?p[k]:p.other)},
+s:function(d,k,p){i18n.c(d,k);return d[k] in p?p[d[k]]:p.other}}
+i18n["colors"] = {
 "red":function(d){return "red"},
 "blue":function(d){return "blue"},
 "green":function(d){return "green"}}
-window.i18n["sub/folder/plural"] = {
-"test":function(d){return "Your "+p(d,"NUM",0,"en",{"one":"message","other":"messages"})+" go here."}}
-})();
+i18n["sub/folder/plural"] = {
+"test":function(d){return "Your "+i18n.p(d,"NUM",0,"en",{"one":"message","other":"messages"})+" go here."}}
+})(this);

--- a/example/fr/i18n.js
+++ b/example/fr/i18n.js
@@ -1,16 +1,13 @@
-(function(){ window.i18n || (window.i18n = {}) 
-var MessageFormat = { locale: {} };
-MessageFormat.locale.fr=function(n){return n===0||n==1?"one":"other"}
-var
-c=function(d){if(!d)throw new Error("MessageFormat: No data passed to function.")},
-n=function(d,k,o){if(isNaN(d[k]))throw new Error("MessageFormat: `"+k+"` isnt a number.");return d[k]-(o||0)},
-v=function(d,k){c(d);return d[k]},
-p=function(d,k,o,l,p){c(d);return p[d[k]]||p[MessageFormat.locale[l](d[k]-o)]||p.other},
-s=function(d,k,p){c(d);return p[d[k]]||p.other};
-window.i18n["colors"] = {
+(function(G){G['i18n']={lc:{"fr":function(n){return n===0||n==1?"one":"other"}},
+c:function(d,k){if(!d)throw new Error("MessageFormat: Data required for '"+k+"'.")},
+n:function(d,k,o){if(isNaN(d[k]))throw new Error("MessageFormat: '"+k+"' isn't a number.");return d[k]-(o||0)},
+v:function(d,k){i18n.c(d,k);return d[k]},
+p:function(d,k,o,l,p){i18n.c(d,k);return d[k] in p?p[d[k]]:(k=i18n.lc[l](d[k]-o),k in p?p[k]:p.other)},
+s:function(d,k,p){i18n.c(d,k);return d[k] in p?p[d[k]]:p.other}}
+i18n["colors"] = {
 "red":function(d){return "rouge"},
 "blue":function(d){return "bleu"},
 "green":function(d){return "vert"}}
-window.i18n["sub/folder/plural"] = {
-"test":function(d){return p(d,"NUM",0,"fr",{"one":"Votre message se trouve","other":"Vos messages se trouvent"})+" ici."}}
-})();
+i18n["sub/folder/plural"] = {
+"test":function(d){return i18n.p(d,"NUM",0,"fr",{"one":"Votre message se trouve","other":"Vos messages se trouvent"})+" ici."}}
+})(this);

--- a/lib/messageformat.dev.js
+++ b/lib/messageformat.dev.js
@@ -10,73 +10,54 @@
 */
 (function ( root ) {
 
-  // Create the contructor function
-  function MessageFormat ( locale, pluralFunc ) {
-    this.locale = locale || "en";
+  function MessageFormat ( locale, pluralFunc, globalName ) {
+    var lc = locale || 'en', lcFile;
     if ( pluralFunc ) {
-      MessageFormat.locale[ this.locale ] = pluralFunc;
+      MessageFormat.locale[lc] = pluralFunc;
     } else {
-      while ( this.locale && ! MessageFormat.locale.hasOwnProperty( this.locale ) ) {
-        this.locale = this.locale.replace(/[-_]?[^-_]*$/, '');
+      while ( lc && ! MessageFormat.locale.hasOwnProperty( lc ) ) {
+        lc = lc.replace(/[-_]?[^-_]*$/, '');
       }
-      if ( ! this.locale ) {
-        if ( typeof module !== 'undefined' && module.exports && typeof require !== 'undefined' ) {
-          // in NodeJS, try to load locale from file
-          this.locale = locale.replace(/[-_].*$/, '');
-          var path = require('path'),
-              fs = require('fs'),
-              vm = require('vm'),
-              localeFile = require.resolve(path.join(__dirname, 'locale', this.locale + '.js'));
-
-          try {
-            var localeCode = fs.readFileSync(localeFile);
-            var script = vm.createScript(localeCode);
-            script.runInNewContext({ MessageFormat: MessageFormat });
-          } catch (ex) {
-            ex.message = 'Locale ' + locale + ' could not be loaded: ' + ex.message;
-            throw ex;
-          }
-        } else {
-          throw new Error( "Plural function not found for locale: " + locale );
-        }
+      if ( ! lc ) {
+        lc = locale.replace(/[-_].*$/, '');
+		MessageFormat.locale[lc] = MessageFormat.loadLocale(lc);
       }
     }
+    this.lc = lc;
+    this.globalName = globalName || 'i18n';
   }
 
-  // methods in common with the generated MessageFormat
-  // check d
-  c=function(d){
-    if(!d){throw new Error("MessageFormat: No data passed to function.")}
-  }
-  // require number
-  n=function(d,k,o){
-    if(isNaN(d[k])){throw new Error("MessageFormat: `"+k+"` isnt a number.")}
-    return d[k] - (o || 0);
-  }
-  // value
-  v=function(d,k){
-    c(d);
-    return d[k];
-  }
-  // plural
-  p=function(d,k,o,l,p){
-    c(d);
-    return d[k] in p ? p[d[k]] : (k = MessageFormat.locale[l](d[k]-o), k in p ? p[k] : p.other);
-  }
-  // select
-  s=function(d,k,p){
-    c(d);
-    return d[k] in p ? p[d[k]] : p.other;
-  }
+  if ( !('locale' in MessageFormat) ) MessageFormat.locale = {};
 
-  // Set up the locales object. Add in english by default
-  MessageFormat.locale = {
-    "en" : function ( n ) {
-      if ( n === 1 ) {
-        return "one";
-      }
-      return "other";
+  MessageFormat.loadLocale = function ( lc ) {
+    try {
+      var lcFile = require('path').join(__dirname, 'locale', lc + '.js'),
+          lcStr = ('' + require('fs').readFileSync(lcFile)).match(/{[^]*}/);
+      if (!lcStr) throw "no function found in file '" + lcFile + "'";
+      return 'function(n)' + lcStr;
+    } catch (ex) {
+      if ( lc == 'en' ) {
+        return 'function(n){return n===1?"one":"other"}';
+	  } else {
+        ex.message = 'Locale ' + lc + ' could not be loaded: ' + ex.message;
+        throw ex;
+	  }
     }
+  };
+
+  MessageFormat.prototype.functions = function () {
+    var l = [];
+    for ( var lc in MessageFormat.locale ) {
+      if ( MessageFormat.locale.hasOwnProperty(lc) ) {
+        l.push(JSON.stringify(lc) + ':' + MessageFormat.locale[lc].toString().trim());
+      }
+    }
+    return '{lc:{' + l.join(',') + '},\n'
+      + 'c:function(d,k){if(!d)throw new Error("MessageFormat: Data required for \'"+k+"\'.")},\n'
+      + 'n:function(d,k,o){if(isNaN(d[k]))throw new Error("MessageFormat: \'"+k+"\' isn\'t a number.");return d[k]-(o||0)},\n'
+      + 'v:function(d,k){' + this.globalName + '.c(d,k);return d[k]},\n'
+      + 'p:function(d,k,o,l,p){' + this.globalName + '.c(d,k);return d[k] in p?p[d[k]]:(k=' + this.globalName + '.lc[l](d[k]-o),k in p?p[k]:p.other)},\n'
+      + 's:function(d,k,p){' + this.globalName + '.c(d,k);return d[k] in p?p[d[k]]:p.other}}';
   };
 
   var mparser = require( './message_parser' );
@@ -117,7 +98,7 @@
         case 'messageFormatElement':
           data.pf_count = data.pf_count || 0;
           if ( ast.output ) {
-            return 'v(d,"' + ast.argumentIndex + '")';
+            return self.globalName + '.v(d,"' + ast.argumentIndex + '")';
           }
           else {
             data.keys[data.pf_count] = '"' + ast.argumentIndex + '"';
@@ -126,12 +107,12 @@
           return '';
         case 'elementFormat':
           if ( ast.key === 'select' ) {
-            return 's(d,' + data.keys[data.pf_count] + ',' + interpMFP( ast.val, data ) + ')';
+            return self.globalName + '.s(d,' + data.keys[data.pf_count] + ',' + interpMFP( ast.val, data ) + ')';
           }
           else if ( ast.key === 'plural' ) {
             data.offset[data.pf_count || 0] = ast.val.offset || 0;
-            return 'p(d,' + data.keys[data.pf_count] + ',' + (data.offset[data.pf_count] || 0)
-              + ',"' + self.locale + '",' + interpMFP( ast.val, data ) + ')';
+            return self.globalName + '.p(d,' + data.keys[data.pf_count] + ',' + (data.offset[data.pf_count] || 0)
+              + ',"' + self.lc + '",' + interpMFP( ast.val, data ) + ')';
           }
           return '';
         /* // Unreachable cases.
@@ -175,7 +156,7 @@
           tmp = '"' + (ast.val || "").replace(/\n/g, '\\n').replace(/"/g, '\\"') + '"';
           if ( data.pf_count ) {
             var o = data.offset[data.pf_count-1];
-            tmp = tmp.replace(/(^|[^\\])#/g, '$1"+n(d,' + data.keys[data.pf_count-1] + (o ? ',' + o : '') + ')+"');
+            tmp = tmp.replace(/(^|[^\\])#/g, '$1"+' + self.globalName + '.n(d,' + data.keys[data.pf_count-1] + (o ? ',' + o : '') + ')+"');
             tmp = tmp.replace(/^""\+/, '').replace(/\+""$/, '');
           }
           return tmp;
@@ -187,12 +168,10 @@
   };
 
   MessageFormat.prototype.compile = function ( message ) {
-    return (new Function( 'MessageFormat',
-      'return ' +
-        this.precompile(
-          this.parse( message )
-        )
-    ))(MessageFormat);
+    return (new Function(
+      'this[\'' + this.globalName + '\']=' + this.functions() + ';' +
+      'return ' + this.precompile( this.parse( message ))
+    ))();
   };
 
 

--- a/lib/messageformat.include.js
+++ b/lib/messageformat.include.js
@@ -1,6 +1,0 @@
-var
-c=function(d){if(!d)throw new Error("MessageFormat: No data passed to function.")},
-n=function(d,k,o){if(isNaN(d[k]))throw new Error("MessageFormat: `"+k+"` isnt a number.");return d[k]-(o||0)},
-v=function(d,k){c(d);return d[k]},
-p=function(d,k,o,l,p){c(d);return d[k] in p?p[d[k]]:(k=MessageFormat.locale[l](d[k]-o),k in p?p[k]:p.other)},
-s=function(d,k,p){c(d);return d[k] in p?p[d[k]]:p.other};

--- a/test/common.js
+++ b/test/common.js
@@ -5,4 +5,3 @@
 // expose the globals that are obtained through `<script>` on the browser
 expect = require('expect.js');
 MessageFormat = require('../messageformat');
-require('../locale/cy');

--- a/test/index.html
+++ b/test/index.html
@@ -8,10 +8,9 @@
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/expect.js/index.js"></script>
     <script>mocha.setup('bdd')</script>
-    <script src="../lib/message_parser.js"></script>
     <script src="../messageformat.js"></script>
     <script src="../locale/cy.js"></script>
-    <script src="../test/tests.js"></script>
+    <script src="tests.js"></script>
   </head>
   <body>
     <h1>messageformat.js Test Suite</h1>

--- a/test/tests.js
+++ b/test/tests.js
@@ -32,11 +32,11 @@ describe( "MessageFormat", function () {
 
     it("should fallback when a base pluralFunc exists", function() {
       var mf = new MessageFormat( 'en-x-test1-test2' );
-      expect(mf.locale).to.be("en");
+      expect(mf.lc).to.be("en");
     });
     it("should fallback when a base pluralFunc exists (underscores)", function() {
       var mf = new MessageFormat( 'en_x_test1_test2' );
-      expect(mf.locale).to.be("en");
+      expect(mf.lc).to.be("en");
     });
 
     it("should bail on non-existing locales", function () {
@@ -44,7 +44,7 @@ describe( "MessageFormat", function () {
     });
 
     it("should default to 'en' when no locale is passed into the constructor", function () {
-      expect((new MessageFormat()).locale).to.be( 'en' );
+      expect((new MessageFormat()).lc).to.be( 'en' );
     });
 
   });
@@ -594,9 +594,9 @@ describe( "MessageFormat", function () {
           "I have {FRIENDS, plural, one{one friend} other{# friends but {ENEMIES, plural, one{one enemy} other{# enemies}}}}."
         );
         expect(mfunc({FRIENDS:0, ENEMIES: 0})).to.eql("I have 0 friends but 0 enemies.");
-        expect(function(){ var x = mfunc({FRIENDS:0}); }).to.throwError(/MessageFormat\: \`ENEMIES\` isnt a number\./);
-        expect(function(){ var x = mfunc({}); }).to.throwError(/MessageFormat\: \`.+\` isnt a number\./);
-        expect(function(){ var x = mfunc({ENEMIES:0}); }).to.throwError(/MessageFormat\: \`FRIENDS\` isnt a number\./);
+        expect(function(){ var x = mfunc({FRIENDS:0}); }).to.throwError(/MessageFormat\: \'ENEMIES\' isn\'t a number\./);
+        expect(function(){ var x = mfunc({}); }).to.throwError(/MessageFormat\: \'.+\' isn\'t a number\./);
+        expect(function(){ var x = mfunc({ENEMIES:0}); }).to.throwError(/MessageFormat\: \'FRIENDS\' isn\'t a number\./);
       });
     });
 


### PR DESCRIPTION
This sets up a user-definable global variable that contains the translations and their required executable code, so no more single-letter functions are leaked into the global namespace.

For direct use, `compile()` returns a function that's ready to use. If using `precompile()` to generate static code for later evaluation and use, the usage should look something like:

``` js
var mf = new MessageFormat('en'),
    gn = 'window["' + mf.globalName + '"]',
    msg = { 'test': 'Your {N, plural, one{message} other{messages}} go here.',
            'friends': 'I have {N, plural, one{one friend} other{# friends}}.' },
    tmp = [],
    output = gn + '=' + mf.functions() + ';\n';
for (var key in msg) {
  var fn_str = mf.precompile(mf.parse(msg[key]));
  tmp.push(JSON.stringify(key) + ':' + fn_str);
}
output += gn + '["msg"]={\n' + tmp.join(',\n') + '};\n'
...
```

Changelog:
- add `MF.functions()` to return array of functions as a string, for
  inclusion in code by `MF.compile()` or `build()` in `bin/messageformat.js`
- add `MF.globalName` (default 'i18n') to define said global variable,
  which is also a new 3rd parameter to `MessageFormat()`
- rm `lib/messageformat.include.js` as obsolete
- wrap up locale loading as `MF.loadLocale()`
- update examples to match changes
