### PR TITLE
prevent empty json to break the syntax of the generated js locale file.

### DIFF
--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -185,6 +185,7 @@ function compiler(mf, nm, obj){
     var str = mf.precompile( mf.parse(value) );
     cmf.push(JSON.stringify(key) + ':' + str + ',');
   });
-  cmf[cmf.length-1] = cmf[cmf.length-1].replace(/,$/, '}');
+  cmf[cmf.length-1] = cmf[cmf.length-1].replace(/,$/, '');
+  cmf.push('};');
   return cmf;
 }


### PR DESCRIPTION
Just a little tweak when dealing with empty json
