### PR TITLE
Move comment to make the CLI executable again

### DIFF
--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -1,20 +1,20 @@
+#!/usr/bin/env node
+
 /**
  * Copyright 2014
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#!/usr/bin/env node
 
 var
   nopt          = require('nopt'),


### PR DESCRIPTION
`bin/messageformat.js` was broken by #56 adding a comment before the `#!/usr/bin/env node` line. So I moved it down a notch.

Also, we should probably add tests for the CLI.
