### PR TITLE
bypass require() on browsers

### DIFF
--- a/lib/messageformat.dev.js
+++ b/lib/messageformat.dev.js
@@ -34,7 +34,7 @@
       }
       if ( ! lc ) {
         lc = locale.replace(/[-_].*$/, '');
-        lcFn = require('make-plural')(lc, {'ordinals':1});
+        lcFn = (typeof require !== 'undefined') && require('make-plural')(lc, {'ordinals':1});
         if (lcFn) MessageFormat.locale[lc] = lcFn;
         else throw 'Locale `' + lc + '` could not be loaded';
       }

--- a/messageformat.js
+++ b/messageformat.js
@@ -34,7 +34,7 @@
       }
       if ( ! lc ) {
         lc = locale.replace(/[-_].*$/, '');
-        lcFn = require('make-plural')(lc, {'ordinals':1});
+        lcFn = (typeof require !== 'undefined') && require('make-plural')(lc, {'ordinals':1});
         if (lcFn) MessageFormat.locale[lc] = lcFn;
         else throw 'Locale `' + lc + '` could not be loaded';
       }


### PR DESCRIPTION
It was already done earlier, but this commit broke it:  https://github.com/SlexAxton/messageformat.js/commit/b668997dad704dbbc3e47b8e0c12a11052d17a03
