### PR TITLE
Parser improvements

### DIFF
--- a/lib/message_parser.pegjs
+++ b/lib/message_parser.pegjs
@@ -133,25 +133,19 @@ argStylePattern
   }
 
 string
-  = ws:_ s:(_ chars _)* {
-    var tmp = [];
-    for( var i = 0; i < s.length; ++i ) {
-      for( var j = 0; j < s[ i ].length; ++j ) {
-        tmp.push(s[i][j]);
-      }
-    }
+  = s:(chars/whitespace)* {
     return {
       type: "string",
-      val: ws + tmp.join('')
+      val: s.join('')
     };
   }
 
 // This is a subset to keep code size down
 // More or less, it has to be a single word
 // that doesn't contain punctuation, etc
-id
-  = _ s1:[0-9a-zA-Z$_]s2:[^ \t\n\r,.+={}]* _ {
-    return s1 + (s2 ? s2.join('') : '');
+id "identifier"
+  = _ s:$([0-9a-zA-Z$_]s2:[^ \t\n\r,.+={}]*) _ {
+    return s;
   }
 
 chars

--- a/lib/message_parser.pegjs
+++ b/lib/message_parser.pegjs
@@ -32,25 +32,25 @@ messageFormatElement
   }
 
 elementFormat
-  = _ t:"plural" _ ',' _ s:pluralStyle _ {
+  = _ t:"plural" _ ',' _ s:pluralFormatPattern _ {
     return {
       type : "elementFormat",
       key  : t,
-      val  : s.val
+      val  : s
     };
   }
-  / _ t:"selectordinal" _ ',' _ s:selectStyle _ {
+  / _ t:"selectordinal" _ ',' _ s:selectFormatPattern _ {
     return {
       type : "elementFormat",
       key  : t,
-      val  : s.val
+      val  : s
     };
   }
-  / _ t:"select" _ ',' _ s:selectStyle _ {
+  / _ t:"select" _ ',' _ s:selectFormatPattern _ {
     return {
       type : "elementFormat",
       key  : t,
-      val  : s.val
+      val  : s
     };
   }
   / _ t:id p:argStylePattern* {
@@ -59,16 +59,6 @@ elementFormat
       key  : t,
       val  : p
     };
-  }
-
-pluralStyle
-  = pfp:pluralFormatPattern {
-    return { type: "pluralStyle", val: pfp };
-  }
-
-selectStyle
-  = sfp:selectFormatPattern {
-    return { type: "selectStyle", val: sfp };
   }
 
 pluralFormatPattern
@@ -159,6 +149,8 @@ char
 
 digits
   = ds:[0-9]+ {
+    //the number might start with 0 but must not be interpreted as an octal number
+    //Hence, the base is passed to parseInt explicitely
     return parseInt((ds.join('')), 10);
   }
 

--- a/lib/message_parser.pegjs
+++ b/lib/message_parser.pegjs
@@ -2,33 +2,22 @@ start
   = messageFormatPattern:messageFormatPattern { return { type: "program", program: messageFormatPattern }; }
 
 messageFormatPattern
-  = s1:string inner:(messageFormatPatternRight)* {
+  = s1:string inner:(messageFormatElement string)* {
     var st = [];
     if ( s1 && s1.val ) {
       st.push( s1 );
     }
-    for( var i in inner ){
-      if ( inner.hasOwnProperty( i ) ) {
-        st.push( inner[ i ] );
+    for( var i = 0; i < inner.length; i++ ){
+      st.push( inner[ i ][ 0 ] );
+      if( inner[ i ][ 1 ].val !== "") {
+        st.push( inner[ i ][ 1 ] );
       }
     }
     return { type: 'messageFormatPattern', statements: st };
   }
 
-messageFormatPatternRight
-  = '{' _ mfe:messageFormatElement _ '}' s1:string {
-    var res = [];
-    if ( mfe ) {
-      res.push(mfe);
-    }
-    if ( s1 && s1.val ) {
-      res.push( s1 );
-    }
-    return { type: "messageFormatPatternRight", statements : res };
-  }
-
 messageFormatElement
-  = argIdx:id efmt:(',' elementFormat)? {
+  = '{' _ argIdx:id efmt:(',' elementFormat)? _ '}' {
     var res = { 
       type: "messageFormatElement",
       argumentIndex: argIdx

--- a/lib/messageformat.dev.js
+++ b/lib/messageformat.dev.js
@@ -107,7 +107,7 @@
     }
   };
 
-  var mparser = require( './message_parser' );
+  var mparser = require( 'pegjs' ).buildParser(require('fs').readFileSync(require('path').join(__dirname, 'message_parser.pegjs'), {encoding: 'utf8'}));
 
   MessageFormat._parse = function () {
     // Bind to itself so error handling works

--- a/lib/messageformat.dev.js
+++ b/lib/messageformat.dev.js
@@ -130,12 +130,6 @@
         tmp = r.join('+') || '""';
         return data.pf_count ? tmp : 'function(d){return ' + tmp + '}';
 
-      case 'messageFormatPatternRight':
-        for ( i = 0; i < ast.statements.length; ++i ) {
-          r.push(this._precompile( ast.statements[i], data ));
-        }
-        return r.join('+');
-
       case 'messageFormatElement':
         data.pf_count = data.pf_count || 0;
         if ( ast.output ) {

--- a/messageformat.js
+++ b/messageformat.js
@@ -184,7 +184,7 @@
               return {
                 type : "elementFormat",
                 key  : t,
-                val  : s.val
+                val  : s
               };
             },
           peg$c15 = "selectordinal",
@@ -198,13 +198,7 @@
                 val  : p
               };
             },
-          peg$c20 = function(pfp) {
-              return { type: "pluralStyle", val: pfp };
-            },
-          peg$c21 = function(sfp) {
-              return { type: "selectStyle", val: sfp };
-            },
-          peg$c22 = function(op, pf) {
+          peg$c20 = function(op, pf) {
               var res = {
                 type: "pluralFormatPattern",
                 pluralForms: pf
@@ -217,85 +211,87 @@
               }
               return res;
             },
-          peg$c23 = "offset",
-          peg$c24 = { type: "literal", value: "offset", description: "\"offset\"" },
-          peg$c25 = ":",
-          peg$c26 = { type: "literal", value: ":", description: "\":\"" },
-          peg$c27 = function(d) {
+          peg$c21 = "offset",
+          peg$c22 = { type: "literal", value: "offset", description: "\"offset\"" },
+          peg$c23 = ":",
+          peg$c24 = { type: "literal", value: ":", description: "\":\"" },
+          peg$c25 = function(d) {
               return d;
             },
-          peg$c28 = function(pf) {
+          peg$c26 = function(pf) {
               return {
                 type: "selectFormatPattern",
                 pluralForms: pf
               };
             },
-          peg$c29 = function(k, mfp) {
+          peg$c27 = function(k, mfp) {
               return {
                 type: "pluralForms",
                 key: k,
                 val: mfp
               };
             },
-          peg$c30 = function(i) {
+          peg$c28 = function(i) {
               return i;
             },
-          peg$c31 = "=",
-          peg$c32 = { type: "literal", value: "=", description: "\"=\"" },
-          peg$c33 = function(p) {
+          peg$c29 = "=",
+          peg$c30 = { type: "literal", value: "=", description: "\"=\"" },
+          peg$c31 = function(p) {
               return p;
             },
-          peg$c34 = function(s) {
+          peg$c32 = function(s) {
               return {
                 type: "string",
                 val: s.join('')
               };
             },
-          peg$c35 = { type: "other", description: "identifier" },
-          peg$c36 = /^[0-9a-zA-Z$_]/,
-          peg$c37 = { type: "class", value: "[0-9a-zA-Z$_]", description: "[0-9a-zA-Z$_]" },
-          peg$c38 = /^[^ \t\n\r,.+={}]/,
-          peg$c39 = { type: "class", value: "[^ \\t\\n\\r,.+={}]", description: "[^ \\t\\n\\r,.+={}]" },
-          peg$c40 = function(s) {
+          peg$c33 = { type: "other", description: "identifier" },
+          peg$c34 = /^[0-9a-zA-Z$_]/,
+          peg$c35 = { type: "class", value: "[0-9a-zA-Z$_]", description: "[0-9a-zA-Z$_]" },
+          peg$c36 = /^[^ \t\n\r,.+={}]/,
+          peg$c37 = { type: "class", value: "[^ \\t\\n\\r,.+={}]", description: "[^ \\t\\n\\r,.+={}]" },
+          peg$c38 = function(s) {
               return s;
             },
-          peg$c41 = function(chars) { return chars.join(''); },
-          peg$c42 = /^[^{}\\\0-\x1F \t\n\r]/,
-          peg$c43 = { type: "class", value: "[^{}\\\\\\0-\\x1F \\t\\n\\r]", description: "[^{}\\\\\\0-\\x1F \\t\\n\\r]" },
-          peg$c44 = function(x) {
+          peg$c39 = function(chars) { return chars.join(''); },
+          peg$c40 = /^[^{}\\\0-\x1F \t\n\r]/,
+          peg$c41 = { type: "class", value: "[^{}\\\\\\0-\\x1F \\t\\n\\r]", description: "[^{}\\\\\\0-\\x1F \\t\\n\\r]" },
+          peg$c42 = function(x) {
               return x;
             },
-          peg$c45 = "\\#",
-          peg$c46 = { type: "literal", value: "\\#", description: "\"\\\\#\"" },
-          peg$c47 = function() {
+          peg$c43 = "\\#",
+          peg$c44 = { type: "literal", value: "\\#", description: "\"\\\\#\"" },
+          peg$c45 = function() {
               return "\\#";
             },
-          peg$c48 = "\\{",
-          peg$c49 = { type: "literal", value: "\\{", description: "\"\\\\{\"" },
-          peg$c50 = function() {
+          peg$c46 = "\\{",
+          peg$c47 = { type: "literal", value: "\\{", description: "\"\\\\{\"" },
+          peg$c48 = function() {
               return "\u007B";
             },
-          peg$c51 = "\\}",
-          peg$c52 = { type: "literal", value: "\\}", description: "\"\\\\}\"" },
-          peg$c53 = function() {
+          peg$c49 = "\\}",
+          peg$c50 = { type: "literal", value: "\\}", description: "\"\\\\}\"" },
+          peg$c51 = function() {
               return "\u007D";
             },
-          peg$c54 = "\\u",
-          peg$c55 = { type: "literal", value: "\\u", description: "\"\\\\u\"" },
-          peg$c56 = function(h1, h2, h3, h4) {
+          peg$c52 = "\\u",
+          peg$c53 = { type: "literal", value: "\\u", description: "\"\\\\u\"" },
+          peg$c54 = function(h1, h2, h3, h4) {
                 return String.fromCharCode(parseInt("0x" + h1 + h2 + h3 + h4));
             },
-          peg$c57 = /^[0-9]/,
-          peg$c58 = { type: "class", value: "[0-9]", description: "[0-9]" },
-          peg$c59 = function(ds) {
+          peg$c55 = /^[0-9]/,
+          peg$c56 = { type: "class", value: "[0-9]", description: "[0-9]" },
+          peg$c57 = function(ds) {
+              //the number might start with 0 but must not be interpreted as an octal number
+              //Hence, the base is passed to parseInt explicitely
               return parseInt((ds.join('')), 10);
             },
-          peg$c60 = /^[0-9a-fA-F]/,
-          peg$c61 = { type: "class", value: "[0-9a-fA-F]", description: "[0-9a-fA-F]" },
-          peg$c62 = { type: "other", description: "whitespace" },
-          peg$c63 = function(w) { return w.join(''); },
-          peg$c64 = /^[ \t\n\r]/,
-          peg$c65 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+          peg$c58 = /^[0-9a-fA-F]/,
+          peg$c59 = { type: "class", value: "[0-9a-fA-F]", description: "[0-9a-fA-F]" },
+          peg$c60 = { type: "other", description: "whitespace" },
+          peg$c61 = function(w) { return w.join(''); },
+          peg$c62 = /^[ \t\n\r]/,
+          peg$c63 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
   
           peg$currPos          = 0,
           peg$reportedPos      = 0,
@@ -641,7 +637,7 @@
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
-                  s6 = peg$parsepluralStyle();
+                  s6 = peg$parsepluralFormatPattern();
                   if (s6 !== peg$FAILED) {
                     s7 = peg$parse_();
                     if (s7 !== peg$FAILED) {
@@ -700,7 +696,7 @@
                 if (s4 !== peg$FAILED) {
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
-                    s6 = peg$parseselectStyle();
+                    s6 = peg$parseselectFormatPattern();
                     if (s6 !== peg$FAILED) {
                       s7 = peg$parse_();
                       if (s7 !== peg$FAILED) {
@@ -759,7 +755,7 @@
                   if (s4 !== peg$FAILED) {
                     s5 = peg$parse_();
                     if (s5 !== peg$FAILED) {
-                      s6 = peg$parseselectStyle();
+                      s6 = peg$parseselectFormatPattern();
                       if (s6 !== peg$FAILED) {
                         s7 = peg$parse_();
                         if (s7 !== peg$FAILED) {
@@ -829,34 +825,6 @@
         return s0;
       }
   
-      function peg$parsepluralStyle() {
-        var s0, s1;
-  
-        s0 = peg$currPos;
-        s1 = peg$parsepluralFormatPattern();
-        if (s1 !== peg$FAILED) {
-          peg$reportedPos = s0;
-          s1 = peg$c20(s1);
-        }
-        s0 = s1;
-  
-        return s0;
-      }
-  
-      function peg$parseselectStyle() {
-        var s0, s1;
-  
-        s0 = peg$currPos;
-        s1 = peg$parseselectFormatPattern();
-        if (s1 !== peg$FAILED) {
-          peg$reportedPos = s0;
-          s1 = peg$c21(s1);
-        }
-        s0 = s1;
-  
-        return s0;
-      }
-  
       function peg$parsepluralFormatPattern() {
         var s0, s1, s2, s3;
   
@@ -874,7 +842,7 @@
           }
           if (s2 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c22(s1, s2);
+            s1 = peg$c20(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -894,22 +862,22 @@
         s0 = peg$currPos;
         s1 = peg$parse_();
         if (s1 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c23) {
-            s2 = peg$c23;
+          if (input.substr(peg$currPos, 6) === peg$c21) {
+            s2 = peg$c21;
             peg$currPos += 6;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c24); }
+            if (peg$silentFails === 0) { peg$fail(peg$c22); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c25;
+                s4 = peg$c23;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c26); }
+                if (peg$silentFails === 0) { peg$fail(peg$c24); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse_();
@@ -919,7 +887,7 @@
                     s7 = peg$parse_();
                     if (s7 !== peg$FAILED) {
                       peg$reportedPos = s0;
-                      s1 = peg$c27(s6);
+                      s1 = peg$c25(s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -965,7 +933,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c28(s1);
+          s1 = peg$c26(s1);
         }
         s0 = s1;
   
@@ -1005,7 +973,7 @@
                       }
                       if (s8 !== peg$FAILED) {
                         peg$reportedPos = s0;
-                        s1 = peg$c29(s2, s6);
+                        s1 = peg$c27(s2, s6);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1050,23 +1018,23 @@
         s1 = peg$parseid();
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c30(s1);
+          s1 = peg$c28(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 61) {
-            s1 = peg$c31;
+            s1 = peg$c29;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c32); }
+            if (peg$silentFails === 0) { peg$fail(peg$c30); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parsedigits();
             if (s2 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c27(s2);
+              s1 = peg$c25(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1102,7 +1070,7 @@
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$reportedPos = s0;
-                  s1 = peg$c33(s4);
+                  s1 = peg$c31(s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1146,7 +1114,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c34(s1);
+          s1 = peg$c32(s1);
         }
         s0 = s1;
   
@@ -1162,30 +1130,30 @@
         if (s1 !== peg$FAILED) {
           s2 = peg$currPos;
           s3 = peg$currPos;
-          if (peg$c36.test(input.charAt(peg$currPos))) {
+          if (peg$c34.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c37); }
+            if (peg$silentFails === 0) { peg$fail(peg$c35); }
           }
           if (s4 !== peg$FAILED) {
             s5 = [];
-            if (peg$c38.test(input.charAt(peg$currPos))) {
+            if (peg$c36.test(input.charAt(peg$currPos))) {
               s6 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c39); }
+              if (peg$silentFails === 0) { peg$fail(peg$c37); }
             }
             while (s6 !== peg$FAILED) {
               s5.push(s6);
-              if (peg$c38.test(input.charAt(peg$currPos))) {
+              if (peg$c36.test(input.charAt(peg$currPos))) {
                 s6 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c39); }
+                if (peg$silentFails === 0) { peg$fail(peg$c37); }
               }
             }
             if (s5 !== peg$FAILED) {
@@ -1207,7 +1175,7 @@
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c40(s2);
+              s1 = peg$c38(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1224,7 +1192,7 @@
         peg$silentFails--;
         if (s0 === peg$FAILED) {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c33); }
         }
   
         return s0;
@@ -1246,7 +1214,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c41(s1);
+          s1 = peg$c39(s1);
         }
         s0 = s1;
   
@@ -1257,68 +1225,68 @@
         var s0, s1, s2, s3, s4, s5;
   
         s0 = peg$currPos;
-        if (peg$c42.test(input.charAt(peg$currPos))) {
+        if (peg$c40.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c43); }
+          if (peg$silentFails === 0) { peg$fail(peg$c41); }
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c44(s1);
+          s1 = peg$c42(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c45) {
-            s1 = peg$c45;
+          if (input.substr(peg$currPos, 2) === peg$c43) {
+            s1 = peg$c43;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c46); }
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
           }
           if (s1 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c47();
+            s1 = peg$c45();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c48) {
-              s1 = peg$c48;
+            if (input.substr(peg$currPos, 2) === peg$c46) {
+              s1 = peg$c46;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c49); }
+              if (peg$silentFails === 0) { peg$fail(peg$c47); }
             }
             if (s1 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c50();
+              s1 = peg$c48();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 2) === peg$c51) {
-                s1 = peg$c51;
+              if (input.substr(peg$currPos, 2) === peg$c49) {
+                s1 = peg$c49;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c52); }
+                if (peg$silentFails === 0) { peg$fail(peg$c50); }
               }
               if (s1 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c53();
+                s1 = peg$c51();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 2) === peg$c54) {
-                  s1 = peg$c54;
+                if (input.substr(peg$currPos, 2) === peg$c52) {
+                  s1 = peg$c52;
                   peg$currPos += 2;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
                 }
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parsehexDigit();
@@ -1330,7 +1298,7 @@
                         s5 = peg$parsehexDigit();
                         if (s5 !== peg$FAILED) {
                           peg$reportedPos = s0;
-                          s1 = peg$c56(s2, s3, s4, s5);
+                          s1 = peg$c54(s2, s3, s4, s5);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -1365,22 +1333,22 @@
   
         s0 = peg$currPos;
         s1 = [];
-        if (peg$c57.test(input.charAt(peg$currPos))) {
+        if (peg$c55.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c58); }
+          if (peg$silentFails === 0) { peg$fail(peg$c56); }
         }
         if (s2 !== peg$FAILED) {
           while (s2 !== peg$FAILED) {
             s1.push(s2);
-            if (peg$c57.test(input.charAt(peg$currPos))) {
+            if (peg$c55.test(input.charAt(peg$currPos))) {
               s2 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c58); }
+              if (peg$silentFails === 0) { peg$fail(peg$c56); }
             }
           }
         } else {
@@ -1388,7 +1356,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c59(s1);
+          s1 = peg$c57(s1);
         }
         s0 = s1;
   
@@ -1398,12 +1366,12 @@
       function peg$parsehexDigit() {
         var s0;
   
-        if (peg$c60.test(input.charAt(peg$currPos))) {
+        if (peg$c58.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c61); }
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
         }
   
         return s0;
@@ -1422,13 +1390,13 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c63(s1);
+          s1 = peg$c61(s1);
         }
         s0 = s1;
         peg$silentFails--;
         if (s0 === peg$FAILED) {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c62); }
+          if (peg$silentFails === 0) { peg$fail(peg$c60); }
         }
   
         return s0;
@@ -1437,12 +1405,12 @@
       function peg$parsewhitespace() {
         var s0;
   
-        if (peg$c64.test(input.charAt(peg$currPos))) {
+        if (peg$c62.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c63); }
         }
   
         return s0;

--- a/messageformat.js
+++ b/messageformat.js
@@ -150,31 +150,22 @@
               if ( s1 && s1.val ) {
                 st.push( s1 );
               }
-              for( var i in inner ){
-                if ( inner.hasOwnProperty( i ) ) {
-                  st.push( inner[ i ] );
+              for( var i = 0; i < inner.length; i++ ){
+                st.push( inner[ i ][ 0 ] );
+                if( inner[ i ][ 1 ].val !== "") {
+                  st.push( inner[ i ][ 1 ] );
                 }
               }
               return { type: 'messageFormatPattern', statements: st };
             },
           peg$c4 = "{",
           peg$c5 = { type: "literal", value: "{", description: "\"{\"" },
-          peg$c6 = "}",
-          peg$c7 = { type: "literal", value: "}", description: "\"}\"" },
-          peg$c8 = function(mfe, s1) {
-              var res = [];
-              if ( mfe ) {
-                res.push(mfe);
-              }
-              if ( s1 && s1.val ) {
-                res.push( s1 );
-              }
-              return { type: "messageFormatPatternRight", statements : res };
-            },
-          peg$c9 = null,
-          peg$c10 = ",",
-          peg$c11 = { type: "literal", value: ",", description: "\",\"" },
-          peg$c12 = function(argIdx, efmt) {
+          peg$c6 = null,
+          peg$c7 = ",",
+          peg$c8 = { type: "literal", value: ",", description: "\",\"" },
+          peg$c9 = "}",
+          peg$c10 = { type: "literal", value: "}", description: "\"}\"" },
+          peg$c11 = function(argIdx, efmt) {
               var res = { 
                 type: "messageFormatElement",
                 argumentIndex: argIdx
@@ -187,33 +178,33 @@
               }
               return res;
             },
-          peg$c13 = "plural",
-          peg$c14 = { type: "literal", value: "plural", description: "\"plural\"" },
-          peg$c15 = function(t, s) {
+          peg$c12 = "plural",
+          peg$c13 = { type: "literal", value: "plural", description: "\"plural\"" },
+          peg$c14 = function(t, s) {
               return {
                 type : "elementFormat",
                 key  : t,
                 val  : s.val
               };
             },
-          peg$c16 = "selectordinal",
-          peg$c17 = { type: "literal", value: "selectordinal", description: "\"selectordinal\"" },
-          peg$c18 = "select",
-          peg$c19 = { type: "literal", value: "select", description: "\"select\"" },
-          peg$c20 = function(t, p) {
+          peg$c15 = "selectordinal",
+          peg$c16 = { type: "literal", value: "selectordinal", description: "\"selectordinal\"" },
+          peg$c17 = "select",
+          peg$c18 = { type: "literal", value: "select", description: "\"select\"" },
+          peg$c19 = function(t, p) {
               return {
                 type : "elementFormat",
                 key  : t,
                 val  : p
               };
             },
-          peg$c21 = function(pfp) {
+          peg$c20 = function(pfp) {
               return { type: "pluralStyle", val: pfp };
             },
-          peg$c22 = function(sfp) {
+          peg$c21 = function(sfp) {
               return { type: "selectStyle", val: sfp };
             },
-          peg$c23 = function(op, pf) {
+          peg$c22 = function(op, pf) {
               var res = {
                 type: "pluralFormatPattern",
                 pluralForms: pf
@@ -226,85 +217,85 @@
               }
               return res;
             },
-          peg$c24 = "offset",
-          peg$c25 = { type: "literal", value: "offset", description: "\"offset\"" },
-          peg$c26 = ":",
-          peg$c27 = { type: "literal", value: ":", description: "\":\"" },
-          peg$c28 = function(d) {
+          peg$c23 = "offset",
+          peg$c24 = { type: "literal", value: "offset", description: "\"offset\"" },
+          peg$c25 = ":",
+          peg$c26 = { type: "literal", value: ":", description: "\":\"" },
+          peg$c27 = function(d) {
               return d;
             },
-          peg$c29 = function(pf) {
+          peg$c28 = function(pf) {
               return {
                 type: "selectFormatPattern",
                 pluralForms: pf
               };
             },
-          peg$c30 = function(k, mfp) {
+          peg$c29 = function(k, mfp) {
               return {
                 type: "pluralForms",
                 key: k,
                 val: mfp
               };
             },
-          peg$c31 = function(i) {
+          peg$c30 = function(i) {
               return i;
             },
-          peg$c32 = "=",
-          peg$c33 = { type: "literal", value: "=", description: "\"=\"" },
-          peg$c34 = function(p) {
+          peg$c31 = "=",
+          peg$c32 = { type: "literal", value: "=", description: "\"=\"" },
+          peg$c33 = function(p) {
               return p;
             },
-          peg$c35 = function(s) {
+          peg$c34 = function(s) {
               return {
                 type: "string",
                 val: s.join('')
               };
             },
-          peg$c36 = { type: "other", description: "identifier" },
-          peg$c37 = /^[0-9a-zA-Z$_]/,
-          peg$c38 = { type: "class", value: "[0-9a-zA-Z$_]", description: "[0-9a-zA-Z$_]" },
-          peg$c39 = /^[^ \t\n\r,.+={}]/,
-          peg$c40 = { type: "class", value: "[^ \\t\\n\\r,.+={}]", description: "[^ \\t\\n\\r,.+={}]" },
-          peg$c41 = function(s) {
+          peg$c35 = { type: "other", description: "identifier" },
+          peg$c36 = /^[0-9a-zA-Z$_]/,
+          peg$c37 = { type: "class", value: "[0-9a-zA-Z$_]", description: "[0-9a-zA-Z$_]" },
+          peg$c38 = /^[^ \t\n\r,.+={}]/,
+          peg$c39 = { type: "class", value: "[^ \\t\\n\\r,.+={}]", description: "[^ \\t\\n\\r,.+={}]" },
+          peg$c40 = function(s) {
               return s;
             },
-          peg$c42 = function(chars) { return chars.join(''); },
-          peg$c43 = /^[^{}\\\0-\x1F \t\n\r]/,
-          peg$c44 = { type: "class", value: "[^{}\\\\\\0-\\x1F \\t\\n\\r]", description: "[^{}\\\\\\0-\\x1F \\t\\n\\r]" },
-          peg$c45 = function(x) {
+          peg$c41 = function(chars) { return chars.join(''); },
+          peg$c42 = /^[^{}\\\0-\x1F \t\n\r]/,
+          peg$c43 = { type: "class", value: "[^{}\\\\\\0-\\x1F \\t\\n\\r]", description: "[^{}\\\\\\0-\\x1F \\t\\n\\r]" },
+          peg$c44 = function(x) {
               return x;
             },
-          peg$c46 = "\\#",
-          peg$c47 = { type: "literal", value: "\\#", description: "\"\\\\#\"" },
-          peg$c48 = function() {
+          peg$c45 = "\\#",
+          peg$c46 = { type: "literal", value: "\\#", description: "\"\\\\#\"" },
+          peg$c47 = function() {
               return "\\#";
             },
-          peg$c49 = "\\{",
-          peg$c50 = { type: "literal", value: "\\{", description: "\"\\\\{\"" },
-          peg$c51 = function() {
+          peg$c48 = "\\{",
+          peg$c49 = { type: "literal", value: "\\{", description: "\"\\\\{\"" },
+          peg$c50 = function() {
               return "\u007B";
             },
-          peg$c52 = "\\}",
-          peg$c53 = { type: "literal", value: "\\}", description: "\"\\\\}\"" },
-          peg$c54 = function() {
+          peg$c51 = "\\}",
+          peg$c52 = { type: "literal", value: "\\}", description: "\"\\\\}\"" },
+          peg$c53 = function() {
               return "\u007D";
             },
-          peg$c55 = "\\u",
-          peg$c56 = { type: "literal", value: "\\u", description: "\"\\\\u\"" },
-          peg$c57 = function(h1, h2, h3, h4) {
+          peg$c54 = "\\u",
+          peg$c55 = { type: "literal", value: "\\u", description: "\"\\\\u\"" },
+          peg$c56 = function(h1, h2, h3, h4) {
                 return String.fromCharCode(parseInt("0x" + h1 + h2 + h3 + h4));
             },
-          peg$c58 = /^[0-9]/,
-          peg$c59 = { type: "class", value: "[0-9]", description: "[0-9]" },
-          peg$c60 = function(ds) {
+          peg$c57 = /^[0-9]/,
+          peg$c58 = { type: "class", value: "[0-9]", description: "[0-9]" },
+          peg$c59 = function(ds) {
               return parseInt((ds.join('')), 10);
             },
-          peg$c61 = /^[0-9a-fA-F]/,
-          peg$c62 = { type: "class", value: "[0-9a-fA-F]", description: "[0-9a-fA-F]" },
-          peg$c63 = { type: "other", description: "whitespace" },
-          peg$c64 = function(w) { return w.join(''); },
-          peg$c65 = /^[ \t\n\r]/,
-          peg$c66 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+          peg$c60 = /^[0-9a-fA-F]/,
+          peg$c61 = { type: "class", value: "[0-9a-fA-F]", description: "[0-9a-fA-F]" },
+          peg$c62 = { type: "other", description: "whitespace" },
+          peg$c63 = function(w) { return w.join(''); },
+          peg$c64 = /^[ \t\n\r]/,
+          peg$c65 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
   
           peg$currPos          = 0,
           peg$reportedPos      = 0,
@@ -487,16 +478,44 @@
       }
   
       function peg$parsemessageFormatPattern() {
-        var s0, s1, s2, s3;
+        var s0, s1, s2, s3, s4, s5;
   
         s0 = peg$currPos;
         s1 = peg$parsestring();
         if (s1 !== peg$FAILED) {
           s2 = [];
-          s3 = peg$parsemessageFormatPatternRight();
+          s3 = peg$currPos;
+          s4 = peg$parsemessageFormatElement();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parsestring();
+            if (s5 !== peg$FAILED) {
+              s4 = [s4, s5];
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$c1;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$c1;
+          }
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            s3 = peg$parsemessageFormatPatternRight();
+            s3 = peg$currPos;
+            s4 = peg$parsemessageFormatElement();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parsestring();
+              if (s5 !== peg$FAILED) {
+                s4 = [s4, s5];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$c1;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$c1;
+            }
           }
           if (s2 !== peg$FAILED) {
             peg$reportedPos = s0;
@@ -514,7 +533,7 @@
         return s0;
       }
   
-      function peg$parsemessageFormatPatternRight() {
+      function peg$parsemessageFormatElement() {
         var s0, s1, s2, s3, s4, s5, s6;
   
         s0 = peg$currPos;
@@ -528,22 +547,45 @@
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parsemessageFormatElement();
+            s3 = peg$parseid();
             if (s3 !== peg$FAILED) {
-              s4 = peg$parse_();
-              if (s4 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 125) {
-                  s5 = peg$c6;
-                  peg$currPos++;
+              s4 = peg$currPos;
+              if (input.charCodeAt(peg$currPos) === 44) {
+                s5 = peg$c7;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c8); }
+              }
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parseelementFormat();
+                if (s6 !== peg$FAILED) {
+                  s5 = [s5, s6];
+                  s4 = s5;
                 } else {
-                  s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c7); }
+                  peg$currPos = s4;
+                  s4 = peg$c1;
                 }
+              } else {
+                peg$currPos = s4;
+                s4 = peg$c1;
+              }
+              if (s4 === peg$FAILED) {
+                s4 = peg$c6;
+              }
+              if (s4 !== peg$FAILED) {
+                s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
-                  s6 = peg$parsestring();
+                  if (input.charCodeAt(peg$currPos) === 125) {
+                    s6 = peg$c9;
+                    peg$currPos++;
+                  } else {
+                    s6 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c10); }
+                  }
                   if (s6 !== peg$FAILED) {
                     peg$reportedPos = s0;
-                    s1 = peg$c8(s3, s6);
+                    s1 = peg$c11(s3, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -573,74 +615,28 @@
         return s0;
       }
   
-      function peg$parsemessageFormatElement() {
-        var s0, s1, s2, s3, s4;
-  
-        s0 = peg$currPos;
-        s1 = peg$parseid();
-        if (s1 !== peg$FAILED) {
-          s2 = peg$currPos;
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s3 = peg$c10;
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c11); }
-          }
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parseelementFormat();
-            if (s4 !== peg$FAILED) {
-              s3 = [s3, s4];
-              s2 = s3;
-            } else {
-              peg$currPos = s2;
-              s2 = peg$c1;
-            }
-          } else {
-            peg$currPos = s2;
-            s2 = peg$c1;
-          }
-          if (s2 === peg$FAILED) {
-            s2 = peg$c9;
-          }
-          if (s2 !== peg$FAILED) {
-            peg$reportedPos = s0;
-            s1 = peg$c12(s1, s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$c1;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$c1;
-        }
-  
-        return s0;
-      }
-  
       function peg$parseelementFormat() {
         var s0, s1, s2, s3, s4, s5, s6, s7;
   
         s0 = peg$currPos;
         s1 = peg$parse_();
         if (s1 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c13) {
-            s2 = peg$c13;
+          if (input.substr(peg$currPos, 6) === peg$c12) {
+            s2 = peg$c12;
             peg$currPos += 6;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c14); }
+            if (peg$silentFails === 0) { peg$fail(peg$c13); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s4 = peg$c10;
+                s4 = peg$c7;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c11); }
+                if (peg$silentFails === 0) { peg$fail(peg$c8); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse_();
@@ -650,7 +646,7 @@
                     s7 = peg$parse_();
                     if (s7 !== peg$FAILED) {
                       peg$reportedPos = s0;
-                      s1 = peg$c15(s2, s6);
+                      s1 = peg$c14(s2, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -684,22 +680,22 @@
           s0 = peg$currPos;
           s1 = peg$parse_();
           if (s1 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 13) === peg$c16) {
-              s2 = peg$c16;
+            if (input.substr(peg$currPos, 13) === peg$c15) {
+              s2 = peg$c15;
               peg$currPos += 13;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c17); }
+              if (peg$silentFails === 0) { peg$fail(peg$c16); }
             }
             if (s2 !== peg$FAILED) {
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 44) {
-                  s4 = peg$c10;
+                  s4 = peg$c7;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c11); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c8); }
                 }
                 if (s4 !== peg$FAILED) {
                   s5 = peg$parse_();
@@ -709,7 +705,7 @@
                       s7 = peg$parse_();
                       if (s7 !== peg$FAILED) {
                         peg$reportedPos = s0;
-                        s1 = peg$c15(s2, s6);
+                        s1 = peg$c14(s2, s6);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -743,22 +739,22 @@
             s0 = peg$currPos;
             s1 = peg$parse_();
             if (s1 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 6) === peg$c18) {
-                s2 = peg$c18;
+              if (input.substr(peg$currPos, 6) === peg$c17) {
+                s2 = peg$c17;
                 peg$currPos += 6;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c19); }
+                if (peg$silentFails === 0) { peg$fail(peg$c18); }
               }
               if (s2 !== peg$FAILED) {
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s4 = peg$c10;
+                    s4 = peg$c7;
                     peg$currPos++;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c11); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c8); }
                   }
                   if (s4 !== peg$FAILED) {
                     s5 = peg$parse_();
@@ -768,7 +764,7 @@
                         s7 = peg$parse_();
                         if (s7 !== peg$FAILED) {
                           peg$reportedPos = s0;
-                          s1 = peg$c15(s2, s6);
+                          s1 = peg$c14(s2, s6);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -812,7 +808,7 @@
                   }
                   if (s3 !== peg$FAILED) {
                     peg$reportedPos = s0;
-                    s1 = peg$c20(s2, s3);
+                    s1 = peg$c19(s2, s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -840,7 +836,7 @@
         s1 = peg$parsepluralFormatPattern();
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c21(s1);
+          s1 = peg$c20(s1);
         }
         s0 = s1;
   
@@ -854,7 +850,7 @@
         s1 = peg$parseselectFormatPattern();
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c22(s1);
+          s1 = peg$c21(s1);
         }
         s0 = s1;
   
@@ -867,7 +863,7 @@
         s0 = peg$currPos;
         s1 = peg$parseoffsetPattern();
         if (s1 === peg$FAILED) {
-          s1 = peg$c9;
+          s1 = peg$c6;
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -878,7 +874,7 @@
           }
           if (s2 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c23(s1, s2);
+            s1 = peg$c22(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -898,22 +894,22 @@
         s0 = peg$currPos;
         s1 = peg$parse_();
         if (s1 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c24) {
-            s2 = peg$c24;
+          if (input.substr(peg$currPos, 6) === peg$c23) {
+            s2 = peg$c23;
             peg$currPos += 6;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c25); }
+            if (peg$silentFails === 0) { peg$fail(peg$c24); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 58) {
-                s4 = peg$c26;
+                s4 = peg$c25;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c27); }
+                if (peg$silentFails === 0) { peg$fail(peg$c26); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parse_();
@@ -923,7 +919,7 @@
                     s7 = peg$parse_();
                     if (s7 !== peg$FAILED) {
                       peg$reportedPos = s0;
-                      s1 = peg$c28(s6);
+                      s1 = peg$c27(s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -969,7 +965,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c29(s1);
+          s1 = peg$c28(s1);
         }
         s0 = s1;
   
@@ -1001,15 +997,15 @@
                     s7 = peg$parse_();
                     if (s7 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 125) {
-                        s8 = peg$c6;
+                        s8 = peg$c9;
                         peg$currPos++;
                       } else {
                         s8 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c7); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c10); }
                       }
                       if (s8 !== peg$FAILED) {
                         peg$reportedPos = s0;
-                        s1 = peg$c30(s2, s6);
+                        s1 = peg$c29(s2, s6);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1054,23 +1050,23 @@
         s1 = peg$parseid();
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c31(s1);
+          s1 = peg$c30(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 61) {
-            s1 = peg$c32;
+            s1 = peg$c31;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c33); }
+            if (peg$silentFails === 0) { peg$fail(peg$c32); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parsedigits();
             if (s2 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c28(s2);
+              s1 = peg$c27(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1092,11 +1088,11 @@
         s1 = peg$parse_();
         if (s1 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s2 = peg$c10;
+            s2 = peg$c7;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c11); }
+            if (peg$silentFails === 0) { peg$fail(peg$c8); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
@@ -1106,7 +1102,7 @@
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$reportedPos = s0;
-                  s1 = peg$c34(s4);
+                  s1 = peg$c33(s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1150,7 +1146,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c35(s1);
+          s1 = peg$c34(s1);
         }
         s0 = s1;
   
@@ -1166,30 +1162,30 @@
         if (s1 !== peg$FAILED) {
           s2 = peg$currPos;
           s3 = peg$currPos;
-          if (peg$c37.test(input.charAt(peg$currPos))) {
+          if (peg$c36.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c38); }
+            if (peg$silentFails === 0) { peg$fail(peg$c37); }
           }
           if (s4 !== peg$FAILED) {
             s5 = [];
-            if (peg$c39.test(input.charAt(peg$currPos))) {
+            if (peg$c38.test(input.charAt(peg$currPos))) {
               s6 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c40); }
+              if (peg$silentFails === 0) { peg$fail(peg$c39); }
             }
             while (s6 !== peg$FAILED) {
               s5.push(s6);
-              if (peg$c39.test(input.charAt(peg$currPos))) {
+              if (peg$c38.test(input.charAt(peg$currPos))) {
                 s6 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c40); }
+                if (peg$silentFails === 0) { peg$fail(peg$c39); }
               }
             }
             if (s5 !== peg$FAILED) {
@@ -1211,7 +1207,7 @@
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c41(s2);
+              s1 = peg$c40(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1228,7 +1224,7 @@
         peg$silentFails--;
         if (s0 === peg$FAILED) {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c36); }
+          if (peg$silentFails === 0) { peg$fail(peg$c35); }
         }
   
         return s0;
@@ -1250,7 +1246,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c42(s1);
+          s1 = peg$c41(s1);
         }
         s0 = s1;
   
@@ -1261,68 +1257,68 @@
         var s0, s1, s2, s3, s4, s5;
   
         s0 = peg$currPos;
-        if (peg$c43.test(input.charAt(peg$currPos))) {
+        if (peg$c42.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c43); }
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c45(s1);
+          s1 = peg$c44(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c46) {
-            s1 = peg$c46;
+          if (input.substr(peg$currPos, 2) === peg$c45) {
+            s1 = peg$c45;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c47); }
+            if (peg$silentFails === 0) { peg$fail(peg$c46); }
           }
           if (s1 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c48();
+            s1 = peg$c47();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c49) {
-              s1 = peg$c49;
+            if (input.substr(peg$currPos, 2) === peg$c48) {
+              s1 = peg$c48;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c50); }
+              if (peg$silentFails === 0) { peg$fail(peg$c49); }
             }
             if (s1 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c51();
+              s1 = peg$c50();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 2) === peg$c52) {
-                s1 = peg$c52;
+              if (input.substr(peg$currPos, 2) === peg$c51) {
+                s1 = peg$c51;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c53); }
+                if (peg$silentFails === 0) { peg$fail(peg$c52); }
               }
               if (s1 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c54();
+                s1 = peg$c53();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 2) === peg$c55) {
-                  s1 = peg$c55;
+                if (input.substr(peg$currPos, 2) === peg$c54) {
+                  s1 = peg$c54;
                   peg$currPos += 2;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c56); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c55); }
                 }
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parsehexDigit();
@@ -1334,7 +1330,7 @@
                         s5 = peg$parsehexDigit();
                         if (s5 !== peg$FAILED) {
                           peg$reportedPos = s0;
-                          s1 = peg$c57(s2, s3, s4, s5);
+                          s1 = peg$c56(s2, s3, s4, s5);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -1369,22 +1365,22 @@
   
         s0 = peg$currPos;
         s1 = [];
-        if (peg$c58.test(input.charAt(peg$currPos))) {
+        if (peg$c57.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c59); }
+          if (peg$silentFails === 0) { peg$fail(peg$c58); }
         }
         if (s2 !== peg$FAILED) {
           while (s2 !== peg$FAILED) {
             s1.push(s2);
-            if (peg$c58.test(input.charAt(peg$currPos))) {
+            if (peg$c57.test(input.charAt(peg$currPos))) {
               s2 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c59); }
+              if (peg$silentFails === 0) { peg$fail(peg$c58); }
             }
           }
         } else {
@@ -1392,7 +1388,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c60(s1);
+          s1 = peg$c59(s1);
         }
         s0 = s1;
   
@@ -1402,12 +1398,12 @@
       function peg$parsehexDigit() {
         var s0;
   
-        if (peg$c61.test(input.charAt(peg$currPos))) {
+        if (peg$c60.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c62); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
   
         return s0;
@@ -1426,13 +1422,13 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c64(s1);
+          s1 = peg$c63(s1);
         }
         s0 = s1;
         peg$silentFails--;
         if (s0 === peg$FAILED) {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c63); }
+          if (peg$silentFails === 0) { peg$fail(peg$c62); }
         }
   
         return s0;
@@ -1441,12 +1437,12 @@
       function peg$parsewhitespace() {
         var s0;
   
-        if (peg$c65.test(input.charAt(peg$currPos))) {
+        if (peg$c64.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
   
         return s0;
@@ -1491,12 +1487,6 @@
         }
         tmp = r.join('+') || '""';
         return data.pf_count ? tmp : 'function(d){return ' + tmp + '}';
-
-      case 'messageFormatPatternRight':
-        for ( i = 0; i < ast.statements.length; ++i ) {
-          r.push(this._precompile( ast.statements[i], data ));
-        }
-        return r.join('+');
 
       case 'messageFormatElement':
         data.pf_count = data.pf_count || 0;

--- a/messageformat.js
+++ b/messageformat.js
@@ -254,62 +254,57 @@
           peg$c34 = function(p) {
               return p;
             },
-          peg$c35 = function(ws, s) {
-              var tmp = [];
-              for( var i = 0; i < s.length; ++i ) {
-                for( var j = 0; j < s[ i ].length; ++j ) {
-                  tmp.push(s[i][j]);
-                }
-              }
+          peg$c35 = function(s) {
               return {
                 type: "string",
-                val: ws + tmp.join('')
+                val: s.join('')
               };
             },
-          peg$c36 = /^[0-9a-zA-Z$_]/,
-          peg$c37 = { type: "class", value: "[0-9a-zA-Z$_]", description: "[0-9a-zA-Z$_]" },
-          peg$c38 = /^[^ \t\n\r,.+={}]/,
-          peg$c39 = { type: "class", value: "[^ \\t\\n\\r,.+={}]", description: "[^ \\t\\n\\r,.+={}]" },
-          peg$c40 = function(s1, s2) {
-              return s1 + (s2 ? s2.join('') : '');
+          peg$c36 = { type: "other", description: "identifier" },
+          peg$c37 = /^[0-9a-zA-Z$_]/,
+          peg$c38 = { type: "class", value: "[0-9a-zA-Z$_]", description: "[0-9a-zA-Z$_]" },
+          peg$c39 = /^[^ \t\n\r,.+={}]/,
+          peg$c40 = { type: "class", value: "[^ \\t\\n\\r,.+={}]", description: "[^ \\t\\n\\r,.+={}]" },
+          peg$c41 = function(s) {
+              return s;
             },
-          peg$c41 = function(chars) { return chars.join(''); },
-          peg$c42 = /^[^{}\\\0-\x1F \t\n\r]/,
-          peg$c43 = { type: "class", value: "[^{}\\\\\\0-\\x1F \\t\\n\\r]", description: "[^{}\\\\\\0-\\x1F \\t\\n\\r]" },
-          peg$c44 = function(x) {
+          peg$c42 = function(chars) { return chars.join(''); },
+          peg$c43 = /^[^{}\\\0-\x1F \t\n\r]/,
+          peg$c44 = { type: "class", value: "[^{}\\\\\\0-\\x1F \\t\\n\\r]", description: "[^{}\\\\\\0-\\x1F \\t\\n\\r]" },
+          peg$c45 = function(x) {
               return x;
             },
-          peg$c45 = "\\#",
-          peg$c46 = { type: "literal", value: "\\#", description: "\"\\\\#\"" },
-          peg$c47 = function() {
+          peg$c46 = "\\#",
+          peg$c47 = { type: "literal", value: "\\#", description: "\"\\\\#\"" },
+          peg$c48 = function() {
               return "\\#";
             },
-          peg$c48 = "\\{",
-          peg$c49 = { type: "literal", value: "\\{", description: "\"\\\\{\"" },
-          peg$c50 = function() {
+          peg$c49 = "\\{",
+          peg$c50 = { type: "literal", value: "\\{", description: "\"\\\\{\"" },
+          peg$c51 = function() {
               return "\u007B";
             },
-          peg$c51 = "\\}",
-          peg$c52 = { type: "literal", value: "\\}", description: "\"\\\\}\"" },
-          peg$c53 = function() {
+          peg$c52 = "\\}",
+          peg$c53 = { type: "literal", value: "\\}", description: "\"\\\\}\"" },
+          peg$c54 = function() {
               return "\u007D";
             },
-          peg$c54 = "\\u",
-          peg$c55 = { type: "literal", value: "\\u", description: "\"\\\\u\"" },
-          peg$c56 = function(h1, h2, h3, h4) {
+          peg$c55 = "\\u",
+          peg$c56 = { type: "literal", value: "\\u", description: "\"\\\\u\"" },
+          peg$c57 = function(h1, h2, h3, h4) {
                 return String.fromCharCode(parseInt("0x" + h1 + h2 + h3 + h4));
             },
-          peg$c57 = /^[0-9]/,
-          peg$c58 = { type: "class", value: "[0-9]", description: "[0-9]" },
-          peg$c59 = function(ds) {
+          peg$c58 = /^[0-9]/,
+          peg$c59 = { type: "class", value: "[0-9]", description: "[0-9]" },
+          peg$c60 = function(ds) {
               return parseInt((ds.join('')), 10);
             },
-          peg$c60 = /^[0-9a-fA-F]/,
-          peg$c61 = { type: "class", value: "[0-9a-fA-F]", description: "[0-9a-fA-F]" },
-          peg$c62 = { type: "other", description: "whitespace" },
-          peg$c63 = function(w) { return w.join(''); },
-          peg$c64 = /^[ \t\n\r]/,
-          peg$c65 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+          peg$c61 = /^[0-9a-fA-F]/,
+          peg$c62 = { type: "class", value: "[0-9a-fA-F]", description: "[0-9a-fA-F]" },
+          peg$c63 = { type: "other", description: "whitespace" },
+          peg$c64 = function(w) { return w.join(''); },
+          peg$c65 = /^[ \t\n\r]/,
+          peg$c66 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
   
           peg$currPos          = 0,
           peg$reportedPos      = 0,
@@ -1138,25 +1133,68 @@
       }
   
       function peg$parsestring() {
+        var s0, s1, s2;
+  
+        s0 = peg$currPos;
+        s1 = [];
+        s2 = peg$parsechars();
+        if (s2 === peg$FAILED) {
+          s2 = peg$parsewhitespace();
+        }
+        while (s2 !== peg$FAILED) {
+          s1.push(s2);
+          s2 = peg$parsechars();
+          if (s2 === peg$FAILED) {
+            s2 = peg$parsewhitespace();
+          }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c35(s1);
+        }
+        s0 = s1;
+  
+        return s0;
+      }
+  
+      function peg$parseid() {
         var s0, s1, s2, s3, s4, s5, s6;
   
+        peg$silentFails++;
         s0 = peg$currPos;
         s1 = peg$parse_();
         if (s1 !== peg$FAILED) {
-          s2 = [];
+          s2 = peg$currPos;
           s3 = peg$currPos;
-          s4 = peg$parse_();
+          if (peg$c37.test(input.charAt(peg$currPos))) {
+            s4 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c38); }
+          }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsechars();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse_();
-              if (s6 !== peg$FAILED) {
-                s4 = [s4, s5, s6];
-                s3 = s4;
+            s5 = [];
+            if (peg$c39.test(input.charAt(peg$currPos))) {
+              s6 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s6 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c40); }
+            }
+            while (s6 !== peg$FAILED) {
+              s5.push(s6);
+              if (peg$c39.test(input.charAt(peg$currPos))) {
+                s6 = input.charAt(peg$currPos);
+                peg$currPos++;
               } else {
-                peg$currPos = s3;
-                s3 = peg$c1;
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c40); }
               }
+            }
+            if (s5 !== peg$FAILED) {
+              s4 = [s4, s5];
+              s3 = s4;
             } else {
               peg$currPos = s3;
               s3 = peg$c1;
@@ -1165,88 +1203,16 @@
             peg$currPos = s3;
             s3 = peg$c1;
           }
-          while (s3 !== peg$FAILED) {
-            s2.push(s3);
-            s3 = peg$currPos;
-            s4 = peg$parse_();
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parsechars();
-              if (s5 !== peg$FAILED) {
-                s6 = peg$parse_();
-                if (s6 !== peg$FAILED) {
-                  s4 = [s4, s5, s6];
-                  s3 = s4;
-                } else {
-                  peg$currPos = s3;
-                  s3 = peg$c1;
-                }
-              } else {
-                peg$currPos = s3;
-                s3 = peg$c1;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$c1;
-            }
+          if (s3 !== peg$FAILED) {
+            s3 = input.substring(s2, peg$currPos);
           }
+          s2 = s3;
           if (s2 !== peg$FAILED) {
-            peg$reportedPos = s0;
-            s1 = peg$c35(s1, s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$c1;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$c1;
-        }
-  
-        return s0;
-      }
-  
-      function peg$parseid() {
-        var s0, s1, s2, s3, s4;
-  
-        s0 = peg$currPos;
-        s1 = peg$parse_();
-        if (s1 !== peg$FAILED) {
-          if (peg$c36.test(input.charAt(peg$currPos))) {
-            s2 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c37); }
-          }
-          if (s2 !== peg$FAILED) {
-            s3 = [];
-            if (peg$c38.test(input.charAt(peg$currPos))) {
-              s4 = input.charAt(peg$currPos);
-              peg$currPos++;
-            } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c39); }
-            }
-            while (s4 !== peg$FAILED) {
-              s3.push(s4);
-              if (peg$c38.test(input.charAt(peg$currPos))) {
-                s4 = input.charAt(peg$currPos);
-                peg$currPos++;
-              } else {
-                s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c39); }
-              }
-            }
+            s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
-              s4 = peg$parse_();
-              if (s4 !== peg$FAILED) {
-                peg$reportedPos = s0;
-                s1 = peg$c40(s2, s3);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$c1;
-              }
+              peg$reportedPos = s0;
+              s1 = peg$c41(s2);
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$c1;
@@ -1258,6 +1224,11 @@
         } else {
           peg$currPos = s0;
           s0 = peg$c1;
+        }
+        peg$silentFails--;
+        if (s0 === peg$FAILED) {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c36); }
         }
   
         return s0;
@@ -1279,7 +1250,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c41(s1);
+          s1 = peg$c42(s1);
         }
         s0 = s1;
   
@@ -1290,68 +1261,68 @@
         var s0, s1, s2, s3, s4, s5;
   
         s0 = peg$currPos;
-        if (peg$c42.test(input.charAt(peg$currPos))) {
+        if (peg$c43.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c43); }
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c44(s1);
+          s1 = peg$c45(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c45) {
-            s1 = peg$c45;
+          if (input.substr(peg$currPos, 2) === peg$c46) {
+            s1 = peg$c46;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c46); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s1 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c47();
+            s1 = peg$c48();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c48) {
-              s1 = peg$c48;
+            if (input.substr(peg$currPos, 2) === peg$c49) {
+              s1 = peg$c49;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c49); }
+              if (peg$silentFails === 0) { peg$fail(peg$c50); }
             }
             if (s1 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c50();
+              s1 = peg$c51();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 2) === peg$c51) {
-                s1 = peg$c51;
+              if (input.substr(peg$currPos, 2) === peg$c52) {
+                s1 = peg$c52;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c52); }
+                if (peg$silentFails === 0) { peg$fail(peg$c53); }
               }
               if (s1 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c53();
+                s1 = peg$c54();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 2) === peg$c54) {
-                  s1 = peg$c54;
+                if (input.substr(peg$currPos, 2) === peg$c55) {
+                  s1 = peg$c55;
                   peg$currPos += 2;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c56); }
                 }
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parsehexDigit();
@@ -1363,7 +1334,7 @@
                         s5 = peg$parsehexDigit();
                         if (s5 !== peg$FAILED) {
                           peg$reportedPos = s0;
-                          s1 = peg$c56(s2, s3, s4, s5);
+                          s1 = peg$c57(s2, s3, s4, s5);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -1398,22 +1369,22 @@
   
         s0 = peg$currPos;
         s1 = [];
-        if (peg$c57.test(input.charAt(peg$currPos))) {
+        if (peg$c58.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c58); }
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
         }
         if (s2 !== peg$FAILED) {
           while (s2 !== peg$FAILED) {
             s1.push(s2);
-            if (peg$c57.test(input.charAt(peg$currPos))) {
+            if (peg$c58.test(input.charAt(peg$currPos))) {
               s2 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c58); }
+              if (peg$silentFails === 0) { peg$fail(peg$c59); }
             }
           }
         } else {
@@ -1421,7 +1392,7 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c59(s1);
+          s1 = peg$c60(s1);
         }
         s0 = s1;
   
@@ -1431,12 +1402,12 @@
       function peg$parsehexDigit() {
         var s0;
   
-        if (peg$c60.test(input.charAt(peg$currPos))) {
+        if (peg$c61.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c61); }
+          if (peg$silentFails === 0) { peg$fail(peg$c62); }
         }
   
         return s0;
@@ -1455,13 +1426,13 @@
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c63(s1);
+          s1 = peg$c64(s1);
         }
         s0 = s1;
         peg$silentFails--;
         if (s0 === peg$FAILED) {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c62); }
+          if (peg$silentFails === 0) { peg$fail(peg$c63); }
         }
   
         return s0;
@@ -1470,12 +1441,12 @@
       function peg$parsewhitespace() {
         var s0;
   
-        if (peg$c64.test(input.charAt(peg$currPos))) {
+        if (peg$c65.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c66); }
         }
   
         return s0;

--- a/test/tests.js
+++ b/test/tests.js
@@ -52,6 +52,8 @@ describe( "MessageFormat", function () {
         expect( MessageFormat._parse( '☺☺☺☺' ).program.statements[0].val ).to.be( '☺☺☺☺' );
         expect( MessageFormat._parse( 'This is \n a string' ).program.statements[0].val ).to.be( 'This is \n a string' );
         expect( MessageFormat._parse( '中国话不用彁字。' ).program.statements[0].val ).to.be( '中国话不用彁字。' );
+        expect( MessageFormat._parse( ' \t leading whitspace' ).program.statements[0].val ).to.be( ' \t leading whitspace' );
+        expect( MessageFormat._parse( 'trailing whitespace   \n  ' ).program.statements[0].val ).to.be( 'trailing whitespace   \n  ' );
       });
 
       it("should allow you to escape { and } characters", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -86,28 +86,28 @@ describe( "MessageFormat", function () {
         expect( MessageFormat._parse('\n{test}').program.statements[0].val ).to.be( '\n' );
         expect( MessageFormat._parse(' {test}').program.statements[0].val ).to.be( ' ' );
         expect( MessageFormat._parse('x { test}').program.statements[0].val ).to.be( 'x ' );
-        expect( MessageFormat._parse('x{test} x ').program.statements[1].statements[1].val ).to.be( ' x ' );
+        expect( MessageFormat._parse('x{test} x ').program.statements[2].val ).to.be( ' x ' );
         expect( MessageFormat._parse('x\n{test}\n').program.statements[0].val ).to.be( 'x\n' );
-        expect( MessageFormat._parse('x\n{test}\n').program.statements[1].statements[1].val ).to.be( '\n' );
+        expect( MessageFormat._parse('x\n{test}\n').program.statements[2].val ).to.be( '\n' );
       });
 
       it("should handle extended character literals", function () {
         expect( MessageFormat._parse('☺{test}').program.statements[0].val ).to.be( '☺' );
-        expect( MessageFormat._parse('中{test}中国话不用彁字。').program.statements[1].statements[1].val ).to.be( '中国话不用彁字。' );
+        expect( MessageFormat._parse('中{test}中国话不用彁字。').program.statements[2].val ).to.be( '中国话不用彁字。' );
       });
 
       it("shouldn't matter if it has html or something in it", function () {
         expect( MessageFormat._parse('<div class="test">content: {TEST}</div>').program.statements[0].val ).to.be( '<div class="test">content: ' );
-        expect( MessageFormat._parse('<div class="test">content: {TEST}</div>').program.statements[1].statements[0].argumentIndex ).to.be( 'TEST' );
-        expect( MessageFormat._parse('<div class="test">content: {TEST}</div>').program.statements[1].statements[1].val ).to.be( '</div>' );
+        expect( MessageFormat._parse('<div class="test">content: {TEST}</div>').program.statements[1].argumentIndex ).to.be( 'TEST' );
+        expect( MessageFormat._parse('<div class="test">content: {TEST}</div>').program.statements[2].val ).to.be( '</div>' );
       });
 
       it("should allow you to use extension keywords for plural formats everywhere except where they go", function () {
         expect( MessageFormat._parse('select select, ').program.statements[0].val ).to.eql( 'select select, ' );
         expect( MessageFormat._parse('select offset, offset:1 ').program.statements[0].val ).to.eql( 'select offset, offset:1 ' );
         expect( MessageFormat._parse('one other, =1 ').program.statements[0].val ).to.eql( 'one other, =1 ' );
-        expect( MessageFormat._parse('one {select} ').program.statements[1].statements[0].argumentIndex ).to.eql( 'select' );
-        expect( MessageFormat._parse('one {plural} ').program.statements[1].statements[0].argumentIndex ).to.eql( 'plural' );
+        expect( MessageFormat._parse('one {select} ').program.statements[1].argumentIndex ).to.eql( 'select' );
+        expect( MessageFormat._parse('one {plural} ').program.statements[1].argumentIndex ).to.eql( 'plural' );
       });
     });
 
@@ -128,17 +128,17 @@ describe( "MessageFormat", function () {
       it("should allow you to use MessageFormat extension keywords other places, including in select keys", function () {
         // use `select` as a select key
         expect( MessageFormat._parse( 'x {TEST, select, select{a} other{b} }' )
-                    .program.statements[1].statements[0]
+                    .program.statements[1]
                     .elementFormat.val.pluralForms[0].key
               ).to.eql( 'select' );
         // use `offset` as a key (since it goes here in a `plural` case)
         expect( MessageFormat._parse( 'x {TEST, select, offset{a} other{b} }' )
-                    .program.statements[1].statements[0]
+                    .program.statements[1]
                     .elementFormat.val.pluralForms[0].key
               ).to.eql( 'offset' );
         // use the exact variable name as a key name
         expect( MessageFormat._parse( 'x {TEST, select, TEST{a} other{b} }' )
-                    .program.statements[1].statements[0]
+                    .program.statements[1]
                     .elementFormat.val.pluralForms[0].key
               ).to.eql( 'TEST' );
       });
@@ -159,47 +159,47 @@ describe( "MessageFormat", function () {
 
       it("should accept exact values with `=` prefixes", function () {
         expect(
-          MessageFormat._parse('{NUM, plural, =0{e1} other{2}}').program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse('{NUM, plural, =0{e1} other{2}}').program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 0 );
         expect(
-          MessageFormat._parse('{NUM, plural, =1{e1} other{2}}').program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse('{NUM, plural, =1{e1} other{2}}').program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 1 );
         expect(
-          MessageFormat._parse('{NUM, plural, =2{e1} other{2}}').program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse('{NUM, plural, =2{e1} other{2}}').program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 2 );
         expect(
-          MessageFormat._parse('{NUM, plural, =1{e1} other{2}}').program.statements[0].statements[0].elementFormat.val.pluralForms[1].key
+          MessageFormat._parse('{NUM, plural, =1{e1} other{2}}').program.statements[0].elementFormat.val.pluralForms[1].key
         ).to.eql( "other" );
       });
 
       it("should accept the 6 official keywords", function () {
         // 'zero', 'one', 'two', 'few', 'many' and 'other'
         expect(
-          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 'zero' );
         expect(
-          MessageFormat._parse( '{NUM, plural,   zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse( '{NUM, plural,   zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 'zero' );
         expect(
-          MessageFormat._parse( '{NUM, plural,zero    {0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse( '{NUM, plural,zero    {0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 'zero' );
         expect(
-          MessageFormat._parse( '{NUM, plural,  \nzero\n   {0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse( '{NUM, plural,  \nzero\n   {0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 'zero' );
         expect(
-          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].statements[0].elementFormat.val.pluralForms[1].key
+          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].elementFormat.val.pluralForms[1].key
         ).to.eql( 'one' );
         expect(
-          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].statements[0].elementFormat.val.pluralForms[2].key
+          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].elementFormat.val.pluralForms[2].key
         ).to.eql( 'two' );
         expect(
-          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].statements[0].elementFormat.val.pluralForms[3].key
+          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].elementFormat.val.pluralForms[3].key
         ).to.eql( 'few' );
         expect(
-          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].statements[0].elementFormat.val.pluralForms[4].key
+          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].elementFormat.val.pluralForms[4].key
         ).to.eql( 'many' );
         expect(
-          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].statements[0].elementFormat.val.pluralForms[5].key
+          MessageFormat._parse( '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}' ).program.statements[0].elementFormat.val.pluralForms[5].key
         ).to.eql( 'other' );
       });
 
@@ -219,10 +219,10 @@ describe( "MessageFormat", function () {
         expect( MessageFormat._parse('{NUM,plural,offset:4other{a}}') ).to.be.ok();
 
         expect(
-          MessageFormat._parse('{NUM, plural, offset:4 other{a}}').program.statements[0].statements[0].elementFormat.val.offset
+          MessageFormat._parse('{NUM, plural, offset:4 other{a}}').program.statements[0].elementFormat.val.offset
         ).to.eql( 4 );
         expect(
-          MessageFormat._parse('{NUM,plural,offset:4other{a}}').program.statements[0].statements[0].elementFormat.val.offset
+          MessageFormat._parse('{NUM,plural,offset:4other{a}}').program.statements[0].elementFormat.val.offset
         ).to.eql( 4 );
 
       });
@@ -237,16 +237,16 @@ describe( "MessageFormat", function () {
 
       it("should accept exact values with `=` prefixes", function () {
         expect(
-          MessageFormat._parse('{NUM, selectordinal, =0{e1} other{2}}').program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse('{NUM, selectordinal, =0{e1} other{2}}').program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 0 );
         expect(
-          MessageFormat._parse('{NUM, selectordinal, =1{e1} other{2}}').program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse('{NUM, selectordinal, =1{e1} other{2}}').program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 1 );
         expect(
-          MessageFormat._parse('{NUM, selectordinal, =2{e1} other{2}}').program.statements[0].statements[0].elementFormat.val.pluralForms[0].key
+          MessageFormat._parse('{NUM, selectordinal, =2{e1} other{2}}').program.statements[0].elementFormat.val.pluralForms[0].key
         ).to.eql( 2 );
         expect(
-          MessageFormat._parse('{NUM, selectordinal, =1{e1} other{2}}').program.statements[0].statements[0].elementFormat.val.pluralForms[1].key
+          MessageFormat._parse('{NUM, selectordinal, =1{e1} other{2}}').program.statements[0].elementFormat.val.pluralForms[1].key
         ).to.eql( "other" );
       });
 
@@ -259,8 +259,8 @@ describe( "MessageFormat", function () {
         expect(
           MessageFormat._parse('{NUM1, select, other{{NUM2, select, other{a}}}}')
             .program
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
               .statements[0].val
         ).to.eql( 'a' );
 
@@ -268,9 +268,9 @@ describe( "MessageFormat", function () {
         expect(
          MessageFormat._parse('{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{b}}}}}}')
             .program
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
               .statements[0].val
         ).to.eql( 'b' );
 
@@ -278,10 +278,10 @@ describe( "MessageFormat", function () {
         expect(
          MessageFormat._parse('{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{{NUM4, select, other{c}}}}}}}}')
             .program
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
               .statements[0].val
         ).to.eql( 'c' );
       });
@@ -321,10 +321,10 @@ describe( "MessageFormat", function () {
         expect(
           MessageFormat._parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}')
             .program
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
               .statements[0].val
         ).to.eql('c');
       });
@@ -364,10 +364,10 @@ describe( "MessageFormat", function () {
         expect(
           MessageFormat._parse('{NUM1, selectordinal, other{{NUM2, plural, offset:1 other{{NUM3, selectordinal, other{{NUM4, plural, offset:1 other{c}}}}}}}}')
             .program
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
-              .statements[0].statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
+              .statements[0].elementFormat.val.pluralForms[0].val
               .statements[0].val
         ).to.eql('c');
       });


### PR DESCRIPTION
I am currently getting started with MessageFormat and as a starting point I was reading your definition of the MessageFormat grammar.

Doing so, I noticed some minor things which could be done to simplify the pegjs grammar:

* PegJS grammar:
    * Remove `messageFormatPatternRight` and directly use `messageFormatElement` within `messageFormatPattern`
    * Remove `pluralStyle` and `selectStyle` which were just forwarding to `pluralFormatPattern` respectively `selectFormatPattern`
    * simplified parsing of strings and ids
* automatically compile the grammar in the development version
* I added two new testcases for trailing and leading whitespace in strings

All testcases are passing for messageformat.js and lib/messageformat.dev.js