### PR TITLE
Add JSDoc comments to source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules/**/*
 lib/message_parser.js
+doc/
 
 # Numerous always-ignore extensions
 *.diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - iojs
+  - "0.12"
   - "0.10"
-  - "0.8"

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright 2012-2015 Alex Sexton, Eemeli Aro, and Contributors
+
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # 
-# Copyright 2014
+# Copyright 2012-2014 Alex Sexton, Eemeli Aro, and Contributors
 # 
 # Licensed under the MIT License
 # 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ STOP=\033[0m
 CHK=${GREEN} ✓${STOP}
 ERR=${RED} ✖${STOP}
 
+doc: ./lib/messageformat.dev.js
+	@./node_modules/.bin/jsdoc -c jsdoc-conf.json
+
 test:
 	@npm run test
 

--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Copyright 2014
+ * Copyright 2012-2014 Alex Sexton, Eemeli Aro, and Contributors
  *
  * Licensed under the MIT License
  */

--- a/example/en/i18n.js
+++ b/example/en/i18n.js
@@ -1,16 +1,8 @@
 (function(G){var
-_n=function(v,o){if(isNaN(v))throw new Error("'"+v+"' isn't a number.");return v-(o||0)},
-_p=function(v,o,l,p,s){return v in p?p[v]:(v=l(v-o,s),v in p?p[v]:p.other)},
-_s=function(v,p){return v in p?p[v]:p.other},
-pf={"en":function(n,ord) {
-  var s = String(n).split('.'), v0 = !s[1], t0 = Number(s[0]) == n,
-      n10 = t0 && s[0].substr(-1), n100 = t0 && s[0].substr(-2);
-  if (ord) return (n10 == 1 && n100 != 11) ? 'one'
-      : (n10 == 2 && n100 != 12) ? 'two'
-      : (n10 == 3 && n100 != 13) ? 'few'
-      : 'other';
-  return (n == 1 && v0) ? 'one' : 'other';
-}},
+n=function(v,o){ if (isNaN(v)) throw new Error("'"+v+"' isn't a number."); return v - (o||0) },
+p=function(v,o,l,p,s){ return v in p ? p[v] : ( v = l(v-o,s), v in p ? p[v] : p.other ) },
+s=function(v,p){ return v in p ? p[v] : p.other },
+pf={"en":function(n,ord) { var s = String(n).split('.'), v0 = !s[1], t0 = Number(s[0]) == n, n10 = t0 && s[0].substr(-1), n100 = t0 && s[0].substr(-2); if (ord) return (n10 == 1 && n100 != 11) ? 'one' : (n10 == 2 && n100 != 12) ? 'two' : (n10 == 3 && n100 != 13) ? 'few' : 'other'; return (n == 1 && v0) ? 'one' : 'other'; }},
 fmt={};
 
 G["i18n"] = {
@@ -19,5 +11,5 @@ red:function(d){return "red"},
 blue:function(d){return "blue"},
 green:function(d){return "green"}},
 "sub/folder/plural":{
-test:function(d){return "Your "+_p(d["NUM"],0,pf["en"],{one:"message goes",other:"messages go"})+" here."}}}
+test:function(d){return "Your "+p(d["NUM"],0,pf["en"],{one:"message goes",other:"messages go"})+" here."}}}
 })(this);

--- a/example/fr/i18n.js
+++ b/example/fr/i18n.js
@@ -1,11 +1,8 @@
 (function(G){var
-_n=function(v,o){if(isNaN(v))throw new Error("'"+v+"' isn't a number.");return v-(o||0)},
-_p=function(v,o,l,p,s){return v in p?p[v]:(v=l(v-o,s),v in p?p[v]:p.other)},
-_s=function(v,p){return v in p?p[v]:p.other},
-pf={"fr":function(n,ord) {
-  if (ord) return (n == 1) ? 'one' : 'other';
-  return (n >= 0 && n < 2) ? 'one' : 'other';
-}},
+n=function(v,o){ if (isNaN(v)) throw new Error("'"+v+"' isn't a number."); return v - (o||0) },
+p=function(v,o,l,p,s){ return v in p ? p[v] : ( v = l(v-o,s), v in p ? p[v] : p.other ) },
+s=function(v,p){ return v in p ? p[v] : p.other },
+pf={"fr":function(n,ord) { if (ord) return (n == 1) ? 'one' : 'other'; return (n >= 0 && n < 2) ? 'one' : 'other'; }},
 fmt={};
 
 G["i18n"] = {
@@ -14,5 +11,5 @@ red:function(d){return "rouge"},
 blue:function(d){return "bleu"},
 green:function(d){return "vert"}},
 "sub/folder/plural":{
-test:function(d){return _p(d["NUM"],0,pf["fr"],{one:"Votre message se trouve",other:"Vos messages se trouvent"})+" ici."}}}
+test:function(d){return p(d["NUM"],0,pf["fr"],{one:"Votre message se trouve",other:"Vos messages se trouvent"})+" ici."}}}
 })(this);

--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -1,0 +1,5 @@
+{
+  "source": { "include": [ "lib/messageformat.dev.js" ] },
+  "plugins": [ "plugins/markdown" ],
+  "opts": { "destination": "./doc/" }
+}

--- a/lib/messageformat.dev.js
+++ b/lib/messageformat.dev.js
@@ -1,19 +1,23 @@
 /**
- * messageformat.js
- *
- * ICU PluralFormat + SelectFormat for JavaScript
- * 
- * Copyright 2014
- * 
- * Licensed under the MIT License
- *
+ * @file messageformat.js - ICU PluralFormat + SelectFormat for JavaScript
  * @author Alex Sexton - @SlexAxton
  * @version 0.2.1
- * @contributor_license Dojo CLA
+ * @copyright 2012-2015 Alex Sexton and other contributors
+ * @license To use or fork, MIT. To contribute back, Dojo CLA
  */
+
 
 (function ( root ) {
 
+  /**
+   * Create a new message formatter
+   *
+   * @class
+   * @global
+   * @param {string|string[]} [locale="en"] - The locale to use, with fallbacks
+   * @param {function} [pluralFunc] - Optional custom pluralization function
+   * @param {function[]} [formatters] - Optional custom formatting functions
+   */
   function MessageFormat(locale, pluralFunc, formatters) {
     if (!locale) {
       this.lc = ['en'];
@@ -35,8 +39,39 @@
     }
   }
 
+  /**
+   * Publicly-accessible cache of pluralization functions, this is normally
+   * filled by the internal `getPluralFunc()` function, but may be set
+   * externally if e.g. the external dependency {@link
+   * http://github.com/eemeli/make-plural.js make-plural} is not available.
+   *
+   * @memberof MessageFormat
+   * @type Object.<string,function>
+   * @example
+   * > var MessageFormat = require('messageformat');
+   * > MessageFormat.plurals.en = function(n) {  // cardinal plurals only
+   *     return (n == 1 && !String(n).split('.')[1]) ? 'one' : 'other';
+   *   };
+   * > var mf = new MessageFormat('en');
+   * > var mfunc = mf.compile('You have {N, plural, one{1 item} other{# items}.');
+   * > mfunc({N:'1.0'})
+   * "You have 1.0 items."
+   */
   MessageFormat.plurals = {};
 
+  /**
+   * Look up the plural formatting function for a given locale code.
+   *
+   * If the {@link http://github.com/eemeli/make-plural.js make-plural module}
+   * is not available, the {@link MessageFormat.plurals} object will need to be
+   * pre-populated for this to work.
+   *
+   * @private
+   * @memberof MessageFormat
+   * @requires module:eemeli/make-plural.js
+   * @param {string[]} locale - A preferentially ordered array of locale codes
+   * @returns {function} The first match found for the given locale(s)
+   */
   MessageFormat.getPluralFunc = function(locale) {
     var MakePlural = (typeof require != 'undefined') && require('make-plural') || root.MakePlural || function() { return false; };
     for (var i = 0; i < locale.length; ++i) {
@@ -53,7 +88,40 @@
     return null;
   }
 
-  // note: Intl is not defined in default Node until joyent/node#7676 lands
+  /**
+   * Default number formatting functions in the style of ICU's
+   * {@link http://icu-project.org/apiref/icu4j/com/ibm/icu/text/MessageFormat.html simpleArg syntax}
+   * implemented using the
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl Intl}
+   * object defined by ECMA-402.
+   *
+   * **Note**: Intl is not defined in default Node until 0.11.15 / 0.12.0, so
+   * earlier versions require a {@link https://www.npmjs.com/package/intl polyfill}.
+   * Therefore {@link MessageFormat.withIntlSupport} needs to be true for these
+   * functions to be available for inclusion in the output.
+   *
+   * @see MessageFormat#setIntlSupport
+   *
+   * @namespace
+   * @memberof MessageFormat
+   * @property {function} number - Represent a number as an integer, percent or currency value
+   * @property {function} date - Represent a date as a full/long/default/short string
+   * @property {function} time - Represent a time as a full/long/default/short string
+   * @example
+   * > var MessageFormat = require('messageformat');
+   * > var mf = (new MessageFormat('en')).setIntlSupport(true);
+   * > mf.currency = 'EUR';
+   * > var mfunc = mf.compile("The total is {V,number,currency}.");
+   * > mfunc({V:5.5})
+   * "The total is €5.50."
+   * @example
+   * > var MessageFormat = require('messageformat');
+   * > var mf = new MessageFormat('en', null, {number: MessageFormat.number});
+   * > mf.currency = 'EUR';
+   * > var mfunc = mf.compile("The total is {V,number,currency}.");
+   * > mfunc({V:5.5})
+   * "The total is €5.50."
+   */
   MessageFormat.formatters = {
     number: function(self) {
       return new Function("v,lc,p",
@@ -83,27 +151,94 @@
     }
   };
 
+  /**
+   * Enable or disable support for the default formatters, which require the
+   * `Intl` object. Note that this can't be autodetected, as the environment
+   * in which the formatted text is compiled into Javascript functions is not
+   * necessarily the same environment in which they will get executed.
+   *
+   * @see MessageFormat.formatters
+   *
+   * @memberof MessageFormat
+   * @param {boolean} [enable=true]
+   * @returns {Object} The MessageFormat instance, to allow for chaining
+   * @example
+   * > var Intl = require('intl');
+   * > var MessageFormat = require('messageformat');
+   * > var mf = (new MessageFormat('en')).setIntlSupport(true);
+   * > mf.currency = 'EUR';
+   * > mf.compile("The total is {V,number,currency}.")({V:5.5});
+   * "The total is €5.50."
+   */
   MessageFormat.prototype.setIntlSupport = function(enable) {
-	  this.withIntlSupport = !!enable || (typeof enable == 'undefined');
-	  return this;
+      this.withIntlSupport = !!enable || (typeof enable == 'undefined');
+      return this;
   };
 
+  /**
+   * A set of utility functions that are called by the compiled Javascript
+   * functions, these are included locally in the output of {@link
+   * MessageFormat#compile compile()}.
+   *
+   * @namespace
+   * @memberof MessageFormat
+   */
   MessageFormat.prototype.runtime = {
+    /**
+     * Utility function for `#` in plural rules
+     *
+     * @param {number} v - The value to operate on
+     * @param {number} [o=0] - An optional offset, set by the surrounding context
+     */
     n: function(v,o){
       if (isNaN(v)) throw new Error("'"+v+"' isn't a number.");
       return v - (o||0)
     },
+
+    /**
+     * Utility function for `{N, plural|selectordinal, ...}`
+     *
+     * Outer check is for the presence of `v` as a literal numeric key in `p`,
+     * inner applies offset & looks up plural key from `l`, a locale function
+     * from `pf` that uses `s` to choose between cardinal & ordinal plural rules.
+     *
+     * @param {number} v - The key to use to find a pluralization rule
+     * @param {number} o - An offset to apply to `v`
+     * @param {function} l - A locale function from `pf`
+     * @param {Object.<string,string>} p - The object from which results are looked up
+     * @param {?boolean} s - If true, use ordinal rather than cardinal rules
+     * @returns {string} The result of the pluralization
+     */
     p: function(v,o,l,p,s){
       return v in p ? p[v] : (
         v = l(v-o,s),
         v in p ? p[v] : p.other
       )
     },
+
+    /**
+     * Utility function for `{N, select, ...}`
+     *
+     * @param {number} v - The key to use to find a selection
+     * @param {Object.<string,string>} p - The object from which results are looked up
+     * @returns {string} The result of the select statement
+     */
     s: function(v,p){
       return v in p ? p[v] : p.other
     },
+
+    /** Pluralization functions
+     *  @instance
+     *  @type Object.<string,function>  */
     pf: {},
+
+    /** Custom formatting functions called by `{var, fn[, args]*}` syntax
+     *  @instance
+     *  @see MessageFormat.formatters
+     *  @type Object.<string,function>  */
     fmt: {},
+
+    /** Custom stringifier to clean up browser inconsistencies & minify output */
     toString: function () {
       var _stringify = function(o, top) {
         if (typeof o != 'object') return o.toString().replace(/^(function) \w*/, '$1').replace(/\s+/g, ' ');
@@ -117,16 +252,22 @@
     }
   };
 
+  /** Parse an input string to its AST
+   *  @private */
   MessageFormat._parse = function () {
     var mparser = require('./message_parser');
     // Bind to itself so error handling works
     return mparser.parse.apply( mparser, arguments );
   };
 
+  /** Utility function for quoting an Object's key value iff required
+   *  @private */
   var propname = function(s) {
     return /^[A-Z_$][0-9A-Z_$]*$/i.test(s) ? s : JSON.stringify(s);
   };
 
+  /** Recursively map an AST to its resulting string
+   *  @private */
   MessageFormat.prototype._precompile = function(ast, data) {
     data = data || { keys: {}, offset: {} };
     var r = [], i, tmp, args = [];
@@ -213,6 +354,51 @@
     }
   };
 
+  /**
+   * Compile messages into an executable function with clean string
+   * representation.
+   *
+   * If `messages` is a single string including ICU MessageFormat declarations,
+   * `opt` is ignored and the returned function takes a single Object parameter
+   * `d` representing each of the input's defined variables. The returned
+   * function will be defined in a local scope that includes all the required
+   * runtime variables.
+   *
+   * If `messages` is a map of keys to strings, or a map of namespace keys to
+   * such key/string maps, the returned function will fill the specified global
+   * with javascript functions matching the structure of the input. In such use,
+   * the output of `compile()` is expected to be serialized using `.toString()`,
+   * and will include definitions of the runtime functions.
+   *
+   * Together, the input parameters should match the following patterns:
+   * ```js
+   * messages = "string" || { key0: "string0", key1: "string1", ... } || {
+   *   ns0: { key0: "string0", key1: "string1", ...  },
+   *   ns1: { key0: "string0", key1: "string1", ...  },
+   *   ...
+   * }
+   *
+   * opt = null || {
+   *   locale: null || {
+   *     ns0: "lc0" || [ "lc0", ... ],
+   *     ns1: "lc1" || [ "lc1", ... ],
+   *     ...
+   *   },
+   *   global: null || "module.exports" || "exports" || "i18n" || ...
+   * }
+   * ```
+   *
+   * @memberof MessageFormat
+   * @param {string|Object}
+   *     messages - The input message(s) to be compiled, in ICU MessageFormat
+   * @param {Object} [opt={}] - Options controlling output for non-simple intput
+   * @param {Object} [opt.locale] - The locales to use for the messages, with a
+   *     structure matching that of `messages`
+   * @param {string} [opt.global=""] - The global variable that the output
+   *     function should use, or a null string for none. "exports" and
+   *     "module.exports" are recognised as special cases.
+   * @returns {function} The first match found for the given locale(s)
+   */
   MessageFormat.prototype.compile = function ( messages, opt ) {
     var r = {}, lc0 = this.lc,
         compileMsg = function(self, msg) {

--- a/lib/messageformat.dev.js
+++ b/lib/messageformat.dev.js
@@ -35,7 +35,7 @@
     }
   }
 
-  if (!('plurals' in MessageFormat)) MessageFormat.plurals = {};
+  MessageFormat.plurals = {};
 
   MessageFormat.getPluralFunc = function(locale) {
     var MakePlural = (typeof require != 'undefined') && require('make-plural') || root.MakePlural || function() { return false; };
@@ -89,14 +89,24 @@
   };
 
   MessageFormat.prototype.runtime = {
-    _n: function(v,o){if(isNaN(v))throw new Error("'"+v+"' isn't a number.");return v-(o||0)},
-    _p: function(v,o,l,p,s){return v in p?p[v]:(v=l(v-o,s),v in p?p[v]:p.other)},
-    _s: function(v,p){return v in p?p[v]:p.other},
+    n: function(v,o){
+      if (isNaN(v)) throw new Error("'"+v+"' isn't a number.");
+      return v - (o||0)
+    },
+    p: function(v,o,l,p,s){
+      return v in p ? p[v] : (
+        v = l(v-o,s),
+        v in p ? p[v] : p.other
+      )
+    },
+    s: function(v,p){
+      return v in p ? p[v] : p.other
+    },
     pf: {},
     fmt: {},
     toString: function () {
       var _stringify = function(o, top) {
-        if (typeof o != 'object') return o.toString().replace(/^(function) \w*/, '$1');
+        if (typeof o != 'object') return o.toString().replace(/^(function) \w*/, '$1').replace(/\s+/g, ' ');
         var s = [];
         for (var i in o) if (i != 'toString') {
           s.push((top ? i + '=' : JSON.stringify(i) + ':') + _stringify(o[i], false));
@@ -107,9 +117,8 @@
     }
   };
 
-  var mparser = require( './message_parser' );
-
   MessageFormat._parse = function () {
+    var mparser = require('./message_parser');
     // Bind to itself so error handling works
     return mparser.parse.apply( mparser, arguments );
   };
@@ -152,14 +161,14 @@
         switch (ast.key) {
           case 'select':
             args.push(this._precompile(ast.val, data));
-            return '_s(' + args.join(',') + ')';
+            return 's(' + args.join(',') + ')';
           case 'selectordinal':
             args = args.concat([ 0, 'pf[' + JSON.stringify(this.lc[0]) + ']', this._precompile(ast.val, data), 1 ]);
-            return '_p(' + args.join(',') + ')';
+            return 'p(' + args.join(',') + ')';
           case 'plural':
             data.offset[data.pf_count || 0] = ast.val.offset || 0;
             args = args.concat([ data.offset[data.pf_count] || 0, 'pf[' + JSON.stringify(this.lc[0]) + ']', this._precompile(ast.val, data) ]);
-            return '_p(' + args.join(',') + ')';
+            return 'p(' + args.join(',') + ')';
           default:
             if (this.withIntlSupport && !(ast.key in this.runtime.fmt) && (ast.key in MessageFormat.formatters)) {
               tmp = MessageFormat.formatters[ast.key];
@@ -194,7 +203,7 @@
         if ( data.pf_count ) {
           args = [ 'd[' + data.keys[data.pf_count-1] + ']' ];
           if (data.offset[data.pf_count-1]) args.push(data.offset[data.pf_count-1]);
-          tmp = tmp.replace(/(^|[^\\])#/g, '$1"+' + '_n(' + args.join(',') + ')+"');
+          tmp = tmp.replace(/(^|[^\\])#/g, '$1"+' + 'n(' + args.join(',') + ')+"');
           tmp = tmp.replace(/^""\+/, '').replace(/\+""$/, '');
         }
         return tmp;
@@ -222,8 +231,8 @@
         };
 
     if (typeof messages == 'string') {
-      var f = new Function('_n,_p,_s,pf,fmt', 'return ' + compileMsg(this, messages));
-      return f(this.runtime._n, this.runtime._p, this.runtime._s, this.runtime.pf, this.runtime.fmt);
+      var f = new Function('n,p,s,pf,fmt', 'return ' + compileMsg(this, messages));
+      return f(this.runtime.n, this.runtime.p, this.runtime.s, this.runtime.pf, this.runtime.fmt);
     }
 
     opt = opt || {};

--- a/lib/messageformat.dev.js
+++ b/lib/messageformat.dev.js
@@ -2,7 +2,7 @@
  * @file messageformat.js - ICU PluralFormat + SelectFormat for JavaScript
  * @author Alex Sexton - @SlexAxton
  * @version 0.2.1
- * @copyright 2012-2015 Alex Sexton and other contributors
+ * @copyright 2012-2015 Alex Sexton, Eemeli Aro, and Contributors
  * @license To use or fork, MIT. To contribute back, Dojo CLA
  */
 

--- a/messageformat.js
+++ b/messageformat.js
@@ -2,7 +2,7 @@
  * @file messageformat.js - ICU PluralFormat + SelectFormat for JavaScript
  * @author Alex Sexton - @SlexAxton
  * @version 0.2.1
- * @copyright 2012-2015 Alex Sexton and other contributors
+ * @copyright 2012-2015 Alex Sexton, Eemeli Aro, and Contributors
  * @license To use or fork, MIT. To contribute back, Dojo CLA
  */
 

--- a/messageformat.js
+++ b/messageformat.js
@@ -1,19 +1,23 @@
 /**
- * messageformat.js
- *
- * ICU PluralFormat + SelectFormat for JavaScript
- * 
- * Copyright 2014
- * 
- * Licensed under the MIT License
- *
+ * @file messageformat.js - ICU PluralFormat + SelectFormat for JavaScript
  * @author Alex Sexton - @SlexAxton
  * @version 0.2.1
- * @contributor_license Dojo CLA
+ * @copyright 2012-2015 Alex Sexton and other contributors
+ * @license To use or fork, MIT. To contribute back, Dojo CLA
  */
+
 
 (function ( root ) {
 
+  /**
+   * Create a new message formatter
+   *
+   * @class
+   * @global
+   * @param {string|string[]} [locale="en"] - The locale to use, with fallbacks
+   * @param {function} [pluralFunc] - Optional custom pluralization function
+   * @param {function[]} [formatters] - Optional custom formatting functions
+   */
   function MessageFormat(locale, pluralFunc, formatters) {
     if (!locale) {
       this.lc = ['en'];
@@ -35,8 +39,39 @@
     }
   }
 
-  if (!('plurals' in MessageFormat)) MessageFormat.plurals = {};
+  /**
+   * Publicly-accessible cache of pluralization functions, this is normally
+   * filled by the internal `getPluralFunc()` function, but may be set
+   * externally if e.g. the external dependency {@link
+   * http://github.com/eemeli/make-plural.js make-plural} is not available.
+   *
+   * @memberof MessageFormat
+   * @type Object.<string,function>
+   * @example
+   * > var MessageFormat = require('messageformat');
+   * > MessageFormat.plurals.en = function(n) {  // cardinal plurals only
+   *     return (n == 1 && !String(n).split('.')[1]) ? 'one' : 'other';
+   *   };
+   * > var mf = new MessageFormat('en');
+   * > var mfunc = mf.compile('You have {N, plural, one{1 item} other{# items}.');
+   * > mfunc({N:'1.0'})
+   * "You have 1.0 items."
+   */
+  MessageFormat.plurals = {};
 
+  /**
+   * Look up the plural formatting function for a given locale code.
+   *
+   * If the {@link http://github.com/eemeli/make-plural.js make-plural module}
+   * is not available, the {@link MessageFormat.plurals} object will need to be
+   * pre-populated for this to work.
+   *
+   * @private
+   * @memberof MessageFormat
+   * @requires module:eemeli/make-plural.js
+   * @param {string[]} locale - A preferentially ordered array of locale codes
+   * @returns {function} The first match found for the given locale(s)
+   */
   MessageFormat.getPluralFunc = function(locale) {
     var MakePlural = (typeof require != 'undefined') && require('make-plural') || root.MakePlural || function() { return false; };
     for (var i = 0; i < locale.length; ++i) {
@@ -53,7 +88,40 @@
     return null;
   }
 
-  // note: Intl is not defined in default Node until joyent/node#7676 lands
+  /**
+   * Default number formatting functions in the style of ICU's
+   * {@link http://icu-project.org/apiref/icu4j/com/ibm/icu/text/MessageFormat.html simpleArg syntax}
+   * implemented using the
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl Intl}
+   * object defined by ECMA-402.
+   *
+   * **Note**: Intl is not defined in default Node until 0.11.15 / 0.12.0, so
+   * earlier versions require a {@link https://www.npmjs.com/package/intl polyfill}.
+   * Therefore {@link MessageFormat.withIntlSupport} needs to be true for these
+   * functions to be available for inclusion in the output.
+   *
+   * @see MessageFormat#setIntlSupport
+   *
+   * @namespace
+   * @memberof MessageFormat
+   * @property {function} number - Represent a number as an integer, percent or currency value
+   * @property {function} date - Represent a date as a full/long/default/short string
+   * @property {function} time - Represent a time as a full/long/default/short string
+   * @example
+   * > var MessageFormat = require('messageformat');
+   * > var mf = (new MessageFormat('en')).setIntlSupport(true);
+   * > mf.currency = 'EUR';
+   * > var mfunc = mf.compile("The total is {V,number,currency}.");
+   * > mfunc({V:5.5})
+   * "The total is €5.50."
+   * @example
+   * > var MessageFormat = require('messageformat');
+   * > var mf = new MessageFormat('en', null, {number: MessageFormat.number});
+   * > mf.currency = 'EUR';
+   * > var mfunc = mf.compile("The total is {V,number,currency}.");
+   * > mfunc({V:5.5})
+   * "The total is €5.50."
+   */
   MessageFormat.formatters = {
     number: function(self) {
       return new Function("v,lc,p",
@@ -83,20 +151,97 @@
     }
   };
 
+  /**
+   * Enable or disable support for the default formatters, which require the
+   * `Intl` object. Note that this can't be autodetected, as the environment
+   * in which the formatted text is compiled into Javascript functions is not
+   * necessarily the same environment in which they will get executed.
+   *
+   * @see MessageFormat.formatters
+   *
+   * @memberof MessageFormat
+   * @param {boolean} [enable=true]
+   * @returns {Object} The MessageFormat instance, to allow for chaining
+   * @example
+   * > var Intl = require('intl');
+   * > var MessageFormat = require('messageformat');
+   * > var mf = (new MessageFormat('en')).setIntlSupport(true);
+   * > mf.currency = 'EUR';
+   * > mf.compile("The total is {V,number,currency}.")({V:5.5});
+   * "The total is €5.50."
+   */
   MessageFormat.prototype.setIntlSupport = function(enable) {
-	  this.withIntlSupport = !!enable || (typeof enable == 'undefined');
-	  return this;
+      this.withIntlSupport = !!enable || (typeof enable == 'undefined');
+      return this;
   };
 
+  /**
+   * A set of utility functions that are called by the compiled Javascript
+   * functions, these are included locally in the output of {@link
+   * MessageFormat#compile compile()}.
+   *
+   * @namespace
+   * @memberof MessageFormat
+   */
   MessageFormat.prototype.runtime = {
-    _n: function(v,o){if(isNaN(v))throw new Error("'"+v+"' isn't a number.");return v-(o||0)},
-    _p: function(v,o,l,p,s){return v in p?p[v]:(v=l(v-o,s),v in p?p[v]:p.other)},
-    _s: function(v,p){return v in p?p[v]:p.other},
+    /**
+     * Utility function for `#` in plural rules
+     *
+     * @param {number} v - The value to operate on
+     * @param {number} [o=0] - An optional offset, set by the surrounding context
+     */
+    n: function(v,o){
+      if (isNaN(v)) throw new Error("'"+v+"' isn't a number.");
+      return v - (o||0)
+    },
+
+    /**
+     * Utility function for `{N, plural|selectordinal, ...}`
+     *
+     * Outer check is for the presence of `v` as a literal numeric key in `p`,
+     * inner applies offset & looks up plural key from `l`, a locale function
+     * from `pf` that uses `s` to choose between cardinal & ordinal plural rules.
+     *
+     * @param {number} v - The key to use to find a pluralization rule
+     * @param {number} o - An offset to apply to `v`
+     * @param {function} l - A locale function from `pf`
+     * @param {Object.<string,string>} p - The object from which results are looked up
+     * @param {?boolean} s - If true, use ordinal rather than cardinal rules
+     * @returns {string} The result of the pluralization
+     */
+    p: function(v,o,l,p,s){
+      return v in p ? p[v] : (
+        v = l(v-o,s),
+        v in p ? p[v] : p.other
+      )
+    },
+
+    /**
+     * Utility function for `{N, select, ...}`
+     *
+     * @param {number} v - The key to use to find a selection
+     * @param {Object.<string,string>} p - The object from which results are looked up
+     * @returns {string} The result of the select statement
+     */
+    s: function(v,p){
+      return v in p ? p[v] : p.other
+    },
+
+    /** Pluralization functions
+     *  @instance
+     *  @type Object.<string,function>  */
     pf: {},
+
+    /** Custom formatting functions called by `{var, fn[, args]*}` syntax
+     *  @instance
+     *  @see MessageFormat.formatters
+     *  @type Object.<string,function>  */
     fmt: {},
+
+    /** Custom stringifier to clean up browser inconsistencies & minify output */
     toString: function () {
       var _stringify = function(o, top) {
-        if (typeof o != 'object') return o.toString().replace(/^(function) \w*/, '$1');
+        if (typeof o != 'object') return o.toString().replace(/^(function) \w*/, '$1').replace(/\s+/g, ' ');
         var s = [];
         for (var i in o) if (i != 'toString') {
           s.push((top ? i + '=' : JSON.stringify(i) + ':') + _stringify(o[i], false));
@@ -107,6 +252,9 @@
     }
   };
 
+  /** Parse an input string to its AST
+   *  @private */
+  MessageFormat._parse = function () {
   // This is generated and pulled in for browsers.
   var mparser = (function() {
     /*
@@ -1499,16 +1647,18 @@
       parse:       parse
     };
   })();
-
-  MessageFormat._parse = function () {
     // Bind to itself so error handling works
     return mparser.parse.apply( mparser, arguments );
   };
 
+  /** Utility function for quoting an Object's key value iff required
+   *  @private */
   var propname = function(s) {
     return /^[A-Z_$][0-9A-Z_$]*$/i.test(s) ? s : JSON.stringify(s);
   };
 
+  /** Recursively map an AST to its resulting string
+   *  @private */
   MessageFormat.prototype._precompile = function(ast, data) {
     data = data || { keys: {}, offset: {} };
     var r = [], i, tmp, args = [];
@@ -1543,14 +1693,14 @@
         switch (ast.key) {
           case 'select':
             args.push(this._precompile(ast.val, data));
-            return '_s(' + args.join(',') + ')';
+            return 's(' + args.join(',') + ')';
           case 'selectordinal':
             args = args.concat([ 0, 'pf[' + JSON.stringify(this.lc[0]) + ']', this._precompile(ast.val, data), 1 ]);
-            return '_p(' + args.join(',') + ')';
+            return 'p(' + args.join(',') + ')';
           case 'plural':
             data.offset[data.pf_count || 0] = ast.val.offset || 0;
             args = args.concat([ data.offset[data.pf_count] || 0, 'pf[' + JSON.stringify(this.lc[0]) + ']', this._precompile(ast.val, data) ]);
-            return '_p(' + args.join(',') + ')';
+            return 'p(' + args.join(',') + ')';
           default:
             if (this.withIntlSupport && !(ast.key in this.runtime.fmt) && (ast.key in MessageFormat.formatters)) {
               tmp = MessageFormat.formatters[ast.key];
@@ -1585,7 +1735,7 @@
         if ( data.pf_count ) {
           args = [ 'd[' + data.keys[data.pf_count-1] + ']' ];
           if (data.offset[data.pf_count-1]) args.push(data.offset[data.pf_count-1]);
-          tmp = tmp.replace(/(^|[^\\])#/g, '$1"+' + '_n(' + args.join(',') + ')+"');
+          tmp = tmp.replace(/(^|[^\\])#/g, '$1"+' + 'n(' + args.join(',') + ')+"');
           tmp = tmp.replace(/^""\+/, '').replace(/\+""$/, '');
         }
         return tmp;
@@ -1595,6 +1745,51 @@
     }
   };
 
+  /**
+   * Compile messages into an executable function with clean string
+   * representation.
+   *
+   * If `messages` is a single string including ICU MessageFormat declarations,
+   * `opt` is ignored and the returned function takes a single Object parameter
+   * `d` representing each of the input's defined variables. The returned
+   * function will be defined in a local scope that includes all the required
+   * runtime variables.
+   *
+   * If `messages` is a map of keys to strings, or a map of namespace keys to
+   * such key/string maps, the returned function will fill the specified global
+   * with javascript functions matching the structure of the input. In such use,
+   * the output of `compile()` is expected to be serialized using `.toString()`,
+   * and will include definitions of the runtime functions.
+   *
+   * Together, the input parameters should match the following patterns:
+   * ```js
+   * messages = "string" || { key0: "string0", key1: "string1", ... } || {
+   *   ns0: { key0: "string0", key1: "string1", ...  },
+   *   ns1: { key0: "string0", key1: "string1", ...  },
+   *   ...
+   * }
+   *
+   * opt = null || {
+   *   locale: null || {
+   *     ns0: "lc0" || [ "lc0", ... ],
+   *     ns1: "lc1" || [ "lc1", ... ],
+   *     ...
+   *   },
+   *   global: null || "module.exports" || "exports" || "i18n" || ...
+   * }
+   * ```
+   *
+   * @memberof MessageFormat
+   * @param {string|Object}
+   *     messages - The input message(s) to be compiled, in ICU MessageFormat
+   * @param {Object} [opt={}] - Options controlling output for non-simple intput
+   * @param {Object} [opt.locale] - The locales to use for the messages, with a
+   *     structure matching that of `messages`
+   * @param {string} [opt.global=""] - The global variable that the output
+   *     function should use, or a null string for none. "exports" and
+   *     "module.exports" are recognised as special cases.
+   * @returns {function} The first match found for the given locale(s)
+   */
   MessageFormat.prototype.compile = function ( messages, opt ) {
     var r = {}, lc0 = this.lc,
         compileMsg = function(self, msg) {
@@ -1613,8 +1808,8 @@
         };
 
     if (typeof messages == 'string') {
-      var f = new Function('_n,_p,_s,pf,fmt', 'return ' + compileMsg(this, messages));
-      return f(this.runtime._n, this.runtime._p, this.runtime._s, this.runtime.pf, this.runtime.fmt);
+      var f = new Function('n,p,s,pf,fmt', 'return ' + compileMsg(this, messages));
+      return f(this.runtime.n, this.runtime.p, this.runtime.s, this.runtime.pf, this.runtime.fmt);
     }
 
     opt = opt || {};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bin": {
     "messageformat": "./bin/messageformat.js"
   },
-  "contributors":[
+  "contributors": [
     "Eemeli Aro <eemeli@gmail.com>"
   ],
   "keywords": [
@@ -37,10 +37,11 @@
     "make-plural": "~2.0.0"
   },
   "devDependencies": {
-    "mocha": "*",
     "expect.js": "*",
-    "serve": "*",
-    "pegjs": "*"
+    "jsdoc": "^3.3.0-beta1",
+    "mocha": "*",
+    "pegjs": "*",
+    "serve": "*"
   },
   "license": "To use or fork, MIT License. To contribute back, Dojo CLA"
 }


### PR DESCRIPTION
Working towards better documentation, I added [JSDoc](http://usejsdoc.org/) commentary throughout the source. In addition to being readable _in situ_, it compiles to HTML pretty cleanly.

While at it, I cleaned up the source in a couple of places, most visibly moving `mparser = require('./message_parser')` to be within `MessageFormat._parse`, and removing the `_` prefixes of the runtime functions.

This could be left as is, or we could add `jsdoc` as a dependency, along with a suitable config file and a `make` rule. Here's the minimal `conf.json` I've been using so far:
```json
{
  "source": { "include": [ "lib/messageformat.dev.js" ] },
  "plugins": [ "plugins/markdown" ]
}
```

Regarding the copyright statement, I went for now with "2012-2015 Alex Sexton and other contributors". Is that all right?