### PR TITLE
Fixes #99: Code injection using \u005c

### DIFF
--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -304,13 +304,14 @@ MessageFormat.prototype._precompile = function(ast, data) {
       return '{ ' + r.join(', ') + ' }';
 
     case 'string':
-      tmp = '"' + (ast.val || "").replace(/\n/g, '\\n').replace(/"/g, '\\"') + '"';
+      tmp = JSON.stringify(ast.val || "");
       if ( data.pf_count ) {
         args = [ propname(data.keys[data.pf_count-1], 'd') ];
         if (data.offset[data.pf_count-1]) args.push(data.offset[data.pf_count-1]);
         tmp = tmp.replace(/(^|[^\\])#/g, '$1"+' + 'number(' + args.join(', ') + ')+"');
         tmp = tmp.replace(/^""\+/, '').replace(/\+""$/, '');
       }
+      tmp = tmp.replace(/\\\\#/g, '#');
       return tmp;
 
     default:

--- a/test/tests.js
+++ b/test/tests.js
@@ -441,6 +441,11 @@ describe( "MessageFormat", function () {
         expect((mf.compile('She said "Hello"'))()).to.eql('She said "Hello"');
       });
 
+      it("escapes backslashes (regression test for #99)", function() {
+        var mf = new MessageFormat( 'en' );
+        expect((mf.compile('\\u005c'))()).to.eql('\\');
+      });
+
       it("should get escaped brackets all the way out the other end", function () {
         var mf = new MessageFormat( 'en' );
         expect((mf.compile('\\{\\{\\{'))()).to.eql( "{{{" );


### PR DESCRIPTION
I used `JSON.stringify` to escape special characters instead of a do-it-yourself solution.