### PR TITLE
Escape sequence for a literal backslash

### DIFF
--- a/lib/messageformat-parser.pegjs
+++ b/lib/messageformat-parser.pegjs
@@ -82,6 +82,7 @@ chars
 
 char
   = x:[^{}\\\0-\x1F\x7f \t\n\r] { return x; }
+  / "\\\\" { return "\\"; }
   / "\\#" { return "\\#"; }
   / "\\{" { return "\u007B"; }
   / "\\}" { return "\u007D"; }

--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -304,13 +304,14 @@ MessageFormat.prototype._precompile = function(ast, data) {
       return '{ ' + r.join(', ') + ' }';
 
     case 'string':
-      tmp = '"' + (ast.val || "").replace(/\n/g, '\\n').replace(/"/g, '\\"') + '"';
+      tmp = JSON.stringify(ast.val || "");
       if ( data.pf_count ) {
         args = [ propname(data.keys[data.pf_count-1], 'd') ];
         if (data.offset[data.pf_count-1]) args.push(data.offset[data.pf_count-1]);
         tmp = tmp.replace(/(^|[^\\])#/g, '$1"+' + 'number(' + args.join(', ') + ')+"');
         tmp = tmp.replace(/^""\+/, '').replace(/\+""$/, '');
       }
+      tmp = tmp.replace(/\\\\#/g, '#');
       return tmp;
 
     default:

--- a/test/tests.js
+++ b/test/tests.js
@@ -441,6 +441,11 @@ describe( "MessageFormat", function () {
         expect((mf.compile('She said "Hello"'))()).to.eql('She said "Hello"');
       });
 
+      it("escapes backslashes (regression test for #99)", function() {
+        var mf = new MessageFormat( 'en' );
+        expect((mf.compile('\\u005c'))()).to.eql('\\');
+      });
+
       it("should get escaped brackets all the way out the other end", function () {
         var mf = new MessageFormat( 'en' );
         expect((mf.compile('\\{\\{\\{'))()).to.eql( "{{{" );

--- a/test/tests.js
+++ b/test/tests.js
@@ -446,6 +446,15 @@ describe( "MessageFormat", function () {
         expect((mf.compile('\\u005c'))()).to.eql('\\');
       });
 
+      it("accepts escaped special characters", function() {
+        var mf = new MessageFormat( 'en' );
+        expect((mf.compile('\\{'))()).to.eql('{');
+        expect((mf.compile('\\}'))()).to.eql('}');
+        expect((mf.compile('\\#'))()).to.eql('#');
+        expect((mf.compile('\\\\'))()).to.eql('\\');
+        expect((mf.compile('\\u263A\\u263B'))()).to.eql('☺☻');
+      });
+
       it("should get escaped brackets all the way out the other end", function () {
         var mf = new MessageFormat( 'en' );
         expect((mf.compile('\\{\\{\\{'))()).to.eql( "{{{" );


### PR DESCRIPTION
While fixing #99, I noticed that there is no escape sequence for the backslash itself.

The last commit of this pull request introduces the escape sequence `\\`.
The first two commits are already part of pull request #100 but I included them here as well since an escape sequence for backslashes without properly escaping backslashes in the output is a bad idea.