### PR TITLE
Various small parser improvements

### DIFF
--- a/lib/messageformat-parser.pegjs
+++ b/lib/messageformat-parser.pegjs
@@ -2,13 +2,7 @@ start
   = messageFormatPattern
 
 messageFormatPattern
-  = s1:string inner:(messageFormatElement string)* {
-      var st = [];
-      if (s1 && s1.val) st.push(s1);
-      for (var i = 0; i < inner.length; i++) {
-        st.push(inner[i][0]);
-        if (inner[i][1].val !== "") st.push(inner[i][1]);
-      }
+  = st:(messageFormatElement/string)* {
       return { type: 'messageFormatPattern', statements: st };
     }
 
@@ -41,14 +35,14 @@ elementFormat
     }
 
 pluralFormatPattern
-  = op:offsetPattern? pf:(pluralForms)* {
+  = op:offsetPattern? pf:(pluralForm)+ {
       return { type: "pluralFormatPattern", pluralForms: pf, offset: op || 0 };
     }
 
 offsetPattern
   = _ "offset" _ ":" _ d:digits _ { return d; }
 
-pluralForms
+pluralForm
   = _ k:pluralKey _ "{" _ mfp:messageFormatPattern _ "}" {
       return { key: k, val: mfp };
     }
@@ -58,9 +52,9 @@ pluralKey
   / "=" d:digits { return d; }
 
 selectFormatPattern
-  = pf:selectForms* { return { type: "selectFormatPattern", pluralForms: pf }; }
+  = pf:selectForm+ { return { type: "selectFormatPattern", pluralForms: pf }; }
 
-selectForms
+selectForm
   = _ k:id _ "{" _ mfp:messageFormatPattern _ "}" {
       return { key: k, val: mfp };
     }
@@ -69,7 +63,7 @@ argStylePattern
   = _ "," _ p:id _ { return p; }
 
 string
-  = s:(chars/whitespace)* { return { type: "string", val: s.join('') }; }
+  = s:(chars/whitespace)+ { return { type: "string", val: s.join('') }; }
 
 // This is a subset to keep code size down
 // More or less, it has to be a single word

--- a/lib/messageformat-parser.pegjs
+++ b/lib/messageformat-parser.pegjs
@@ -2,7 +2,7 @@ start
   = messageFormatPattern
 
 messageFormatPattern
-  = st:(messageFormatElement/string)* {
+  = st:(messageFormatElement/string/octothorpe)* {
       return { type: 'messageFormatPattern', statements: st };
     }
 
@@ -62,6 +62,9 @@ selectForm
 argStylePattern
   = _ "," _ p:id _ { return p; }
 
+octothorpe
+  = '#' { return {type: 'octothorpe'}; };
+
 string
   = s:(chars/whitespace)+ { return { type: "string", val: s.join('') }; }
 
@@ -75,8 +78,8 @@ chars
   = chars:char+ { return chars.join(''); }
 
 char
-  = x:[^{}\\\0-\x1F\x7f \t\n\r] { return x; }
-  / "\\#" { return "\\#"; }
+  = x:[^{}#\\\0-\x1F\x7f \t\n\r] { return x; }
+  / "\\#" { return "#"; }
   / "\\{" { return "\u007B"; }
   / "\\}" { return "\u007D"; }
   / "\\u" h1:hexDigit h2:hexDigit h3:hexDigit h4:hexDigit {

--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -241,6 +241,8 @@ MessageFormat.prototype.runtime = {
  *
  *  @memberof MessageFormat
  *
+ *  @param ast - the Ast node for which the JS code should be generated
+ *
  *  @private  */
 MessageFormat.prototype._precompile = function(ast, data) {
   data = data || { keys: {}, offset: {} };
@@ -266,7 +268,7 @@ MessageFormat.prototype._precompile = function(ast, data) {
       return '';
 
     case 'elementFormat':
-      var args = [ propname(data.keys[data.pf_count], 'd') ];
+      args = [ propname(data.keys[data.pf_count], 'd') ];
       switch (ast.key) {
         case 'select':
           args.push(this._precompile(ast.val, data));
@@ -304,12 +306,15 @@ MessageFormat.prototype._precompile = function(ast, data) {
       return '{ ' + r.join(', ') + ' }';
 
     case 'string':
-      tmp = '"' + (ast.val || "").replace(/\n/g, '\\n').replace(/"/g, '\\"') + '"';
+      return '"' + (ast.val || "").replace(/\n/g, '\\n').replace(/"/g, '\\"') + '"';
+
+    case 'octothorpe':
       if ( data.pf_count ) {
         args = [ propname(data.keys[data.pf_count-1], 'd') ];
         if (data.offset[data.pf_count-1]) args.push(data.offset[data.pf_count-1]);
-        tmp = tmp.replace(/(^|[^\\])#/g, '$1"+' + 'number(' + args.join(', ') + ')+"');
-        tmp = tmp.replace(/^""\+/, '').replace(/\+""$/, '');
+        return 'number(' + args.join(', ') + ')';
+      } else {
+        tmp = '"#"';
       }
       return tmp;
 


### PR DESCRIPTION
**The first commit** (7bd124b) contains some minor parser changes:
* simplified the messageFormatPattern rule
* renamed rules: `pluralForms` -> `pluralForm`, `selectForms` -> `selectForm`.
  I prefer the singular since these rules match only one pluralForm / selectForm
* do not accept plural/selectFormatPatterns with 0 plural/selectForms

**The second commit** (250ec41) replaces replaces the current RegExp solution for parsing # placeholders by a PEG.js parser rule.

Pros:
* all parsing is done in the _parse method.
* I consider a PEG.js grammar to be more secure against injections than handcrafted regular expressions (although I don't know about a possible injection with the current RegExp solution)

Cons:
* The generated code for `an octothorpe: #` now looks like `"an octothorpe: " + "#"` instead of `"an octothorpe: #"`. But I am quite sure that uglifyJS will optimize this away.