### PR TITLE
Refactor out non-cli-specific logic

### DIFF
--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -61,9 +61,6 @@ var
   },
   options = (function() {
     var o = nopt(knownOpts, shortHands, process.argv, 2);
-    for (var key in defaults) {
-      o[key] = o[key] || defaults[key];
-    }
     if (o.argv.remain) {
       if (o.argv.remain.length >= 1) o.inputdir = o.argv.remain[0];
       if (o.argv.remain.length >= 2) o.output = o.argv.remain[1];
@@ -83,10 +80,6 @@ var
       console.log(usage.join('\n'));
       process.exit(0);
     }
-    if (fs.existsSync(o.output) && fs.statSync(o.output).isDirectory()) {
-      o.output = Path.join(o.output, 'i18n.js');
-    }
-    o.namespace = o.module ? 'module.exports' : o.namespace.replace(/^window\./, '')
     return o;
   })(),
   _log = (options.verbose ? function(s) { console.log(s); } : function(){});
@@ -121,6 +114,13 @@ function parseFileSync(dir, file) {
 }
 
 function build(options, callback) {
+  for (var key in defaults) {
+    options[key] = options[key] || defaults[key];
+  }
+  if (fs.existsSync(options.output) && fs.statSync(options.output).isDirectory()) {
+    options.output = Path.join(options.output, 'i18n.js');
+  }
+  options.namespace = options.module ? 'module.exports' : options.namespace.replace(/^window\./, '');
   var lc = options.locale.trim().split(/[ ,]+/),
       mf = new MessageFormat(lc[0]),
       messages = {},

--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -151,13 +151,17 @@ function build(options, callback) {
   });
 }
 
-build(options, write);
+function runner(options) {
+  build(options, write);
+}
+
+runner(options);
 
 if (options.watch) {
   _log('watching for changes in ' + options.inputdir + '...\n');
   require('watchr').watch({
     path: options.inputdir,
     ignorePaths: [ options.output ],
-    listener: function(changeType, filePath) { if (/\.json$/.test(filePath)) build(options, write); }
+    listener: function(changeType, filePath) { if (/\.json$/.test(filePath)) runner(options); }
   });
 }

--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -8,11 +8,8 @@
 
 var
   nopt          = require('nopt'),
-  fs            = require('fs'),
   Path          = require('path'),
-  glob          = require('glob'),
-  async         = require('async'),
-  MessageFormat = require('../'),
+  runner        = require('../lib/messageformat-runner'),
   knownOpts = {
     "locale"    : String,
     "inputdir"  : Path,
@@ -35,17 +32,6 @@ var
     "watch"     : "watch `inputdir` for changes",
     "module"    : "create a commonJS module, instead of a global window variable",
     "verbose"   : "print logs for debug"
-  },
-  defaults = {
-    "inputdir"  : process.cwd(),
-    "output"    : process.cwd(),
-    "watch"     : false,
-    "namespace" : 'i18n',
-    "include"   : '**/*.json',
-    "stdout"    : false,
-    "verbose"   : false,
-    "module"    : false,
-    "help"      : false
   },
   shortHands = {
     "l"  : "--locale",
@@ -83,77 +69,6 @@ var
     return o;
   })(),
   _log = (options.verbose ? function(s) { console.log(s); } : function(){});
-
-function write(options, data) {
-  if (options.stdout) { _log(''); return console.log(data); }
-  fs.writeFile( options.output, data, 'utf8', function(err) {
-    if (err) return console.error('--->\t' + err.message);
-    _log(options.output + " written.");
-  });
-}
-
-function parseFileSync(dir, file) {
-  var path = Path.join(dir, file),
-      file_parts = file.split(/[.\/]+/),
-      r = { namespace: null, locale: null, data: null };
-  if (!fs.statSync(path).isFile()) {
-    _log('Skipping ' + file);
-    return null;
-  }
-  r.namespace = file.replace(/\.[^.]*$/, '').replace(/\\/g, '/');
-  for (var i = file_parts.length - 1; i >= 0; --i) {
-    if (file_parts[i] in MessageFormat.plurals) { r.locale = file_parts[i]; break; }
-  }
-  try {
-    _log('Building ' + JSON.stringify(r.namespace) + ' from `' + file + '` with ' + (r.locale ? 'locale ' + JSON.stringify(r.locale) : 'default locale'));
-    r.data = JSON.parse(fs.readFileSync(path, 'utf8'));
-  } catch (ex) {
-    console.error('--->\tRead error in ' + path + ': ' + ex.message);
-  }
-  return r;
-}
-
-function build(options, callback) {
-  for (var key in defaults) {
-    options[key] = options[key] || defaults[key];
-  }
-  if (fs.existsSync(options.output) && fs.statSync(options.output).isDirectory()) {
-    options.output = Path.join(options.output, 'i18n.js');
-  }
-  options.namespace = options.module ? 'module.exports' : options.namespace.replace(/^window\./, '');
-  var lc = options.locale.trim().split(/[ ,]+/),
-      mf = new MessageFormat(lc[0]),
-      messages = {},
-      compileOpt = { global: options.namespace, locale: {} };
-  lc.slice(1).forEach(function(l){
-    var pf = mf.runtime.pluralFuncs[l] = MessageFormat.plurals[l];
-    if (!pf) throw 'Plural function for locale `' + l + '` not found';
-  });
-  _log('Input dir: ' + options.inputdir);
-  _log('Included locales: ' + lc.join(', '));
-  glob(options.include, {cwd: options.inputdir}, function(err, files) {
-    if (!err) async.each(files,
-      function(file, cb) {
-        var r = parseFileSync(options.inputdir, file);
-        if (r && r.data) {
-          messages[r.namespace] = r.data;
-          if (r.locale) compileOpt.locale[r.namespace] = r.locale;
-        }
-        cb();
-      },
-      function() {
-        var fn_str = mf.compile(messages, compileOpt).toString();
-        fn_str = fn_str.replace(/^\s*function\b[^{]*{\s*/, '').replace(/\s*}\s*$/, '');
-        var data = options.module ? fn_str : '(function(G) {\n' + fn_str + '\n})(this);';
-        return callback(options, data.trim() + '\n');
-      }
-    );
-  });
-}
-
-function runner(options) {
-  build(options, write);
-}
 
 runner(options);
 

--- a/lib/messageformat-runner.js
+++ b/lib/messageformat-runner.js
@@ -1,0 +1,92 @@
+var
+  fs            = require('fs'),
+  Path          = require('path'),
+  glob          = require('glob'),
+  async         = require('async'),
+  MessageFormat = require('../'),
+  defaults = {
+    "inputdir"  : process.cwd(),
+    "output"    : process.cwd(),
+    "watch"     : false,
+    "namespace" : 'i18n',
+    "include"   : '**/*.json',
+    "stdout"    : false,
+    "verbose"   : false,
+    "module"    : false,
+    "help"      : false
+  },
+  _log          = function(){};
+
+function write(options, data) {
+  if (options.stdout) { _log(''); return console.log(data); }
+  fs.writeFile( options.output, data, 'utf8', function(err) {
+    if (err) return console.error('--->\t' + err.message);
+    _log(options.output + " written.");
+  });
+}
+
+function parseFileSync(dir, file) {
+  var path = Path.join(dir, file),
+      file_parts = file.split(/[.\/]+/),
+      r = { namespace: null, locale: null, data: null };
+  if (!fs.statSync(path).isFile()) {
+    _log('Skipping ' + file);
+    return null;
+  }
+  r.namespace = file.replace(/\.[^.]*$/, '').replace(/\\/g, '/');
+  for (var i = file_parts.length - 1; i >= 0; --i) {
+    if (file_parts[i] in MessageFormat.plurals) { r.locale = file_parts[i]; break; }
+  }
+  try {
+    _log('Building ' + JSON.stringify(r.namespace) + ' from `' + file + '` with ' + (r.locale ? 'locale ' + JSON.stringify(r.locale) : 'default locale'));
+    r.data = JSON.parse(fs.readFileSync(path, 'utf8'));
+  } catch (ex) {
+    console.error('--->\tRead error in ' + path + ': ' + ex.message);
+  }
+  return r;
+}
+
+function build(options, callback) {
+  for (var key in defaults) {
+    options[key] = options[key] || defaults[key];
+  }
+  options.verbose && (_log = function(s) { console.log(s); });
+  if (fs.existsSync(options.output) && fs.statSync(options.output).isDirectory()) {
+    options.output = Path.join(options.output, 'i18n.js');
+  }
+  options.namespace = options.module ? 'module.exports' : options.namespace.replace(/^window\./, '');
+  var lc = options.locale.trim().split(/[ ,]+/),
+      mf = new MessageFormat(lc[0]),
+      messages = {},
+      compileOpt = { global: options.namespace, locale: {} };
+  lc.slice(1).forEach(function(l){
+    var pf = mf.runtime.pluralFuncs[l] = MessageFormat.plurals[l];
+    if (!pf) throw 'Plural function for locale `' + l + '` not found';
+  });
+  _log('Input dir: ' + options.inputdir);
+  _log('Included locales: ' + lc.join(', '));
+  glob(options.include, {cwd: options.inputdir}, function(err, files) {
+    if (!err) async.each(files,
+      function(file, cb) {
+        var r = parseFileSync(options.inputdir, file);
+        if (r && r.data) {
+          messages[r.namespace] = r.data;
+          if (r.locale) compileOpt.locale[r.namespace] = r.locale;
+        }
+        cb();
+      },
+      function() {
+        var fn_str = mf.compile(messages, compileOpt).toString();
+        fn_str = fn_str.replace(/^\s*function\b[^{]*{\s*/, '').replace(/\s*}\s*$/, '');
+        var data = options.module ? fn_str : '(function(G) {\n' + fn_str + '\n})(this);';
+        return callback(options, data.trim() + '\n');
+      }
+    );
+  });
+}
+
+function runner(options) {
+  build(options, write);
+}
+
+module.exports = runner;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "files": [
     "lib/messageformat.js",
     "lib/messageformat-parser.js",
+    "lib/messageformat-runner.js",
     "bin/messageformat.js",
     "example",
     "LICENSE",


### PR DESCRIPTION
This enables other tools (like [grunt-messageformat](https://github.com/gushov/grunt-messageformat)) to reuse the globbing/writing code.