### PR TITLE
Package.json - Added browser config for fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   },
   "scripts": {
     "test": "make test"
+  },
+  "browser": {
+    "fs": false
   }
 }


### PR DESCRIPTION
So as to avoid webpack warnings being thrown when compiling an app with messageformat in, we need to specify a browser definition for fs.

From the creator of weback to jade:
https://github.com/jadejs/jade/pull/1644