### PR TITLE
messageformat.js: Provide Bidi Text Direction and Structured Text support to MessageFormat

### DIFF
--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -133,6 +133,48 @@ MessageFormat.formatters = {
   }
 };
 
+/** Predefined number formatting function enforcing Bidi Text Direction and Structured Text by using UCC
+ * Prevents intermingling of text contained in placeholders with the rest of message text.
+ * Maintains the integrity of Bidi text flowing according to directionality of language script.
+ * Enforces 'contextual' Bidi text direction on placeholder content 
+ *  i.e. text direction is defined by first strong character of placeholder text - 
+ *  'right-to-left' if first strong character is bidi (Hebrew/Arabic) and 'left-to-right' othervise.
+ * For reference to Bidi strucctured text see: http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text
+ * For reference to Bidi text direction see: http://w3-03.ibm.com/globalization/page/publish/4353
+ *  @param {string} - Placeholder text content
+ *  @param {string} - Locale
+ *  @returns {string} - The resultant text fixed by UCC Bidi strong marks
+ *  @examples: (upper case stands for Bidi (Arabic/Hebrew) characters
+ *  > var MessageFormat = require('messageformat');
+ *  > var mf = new MessageFormat('en', null, {"bidiStructuredText": Globalize.messageFormatter.formatters.bidiStructuredText} );
+ *  > var mfunc = mf.compile("{0} >> {1} >> {2}");
+ *  > mfunc([ "first_english_word", "SECOND_ARABIC_WORD", "THIRD_ARABIC_WORD" ])
+ * structured output:
+ *     "first_english_word >> SECOND_ARABIC_WORD  >> THIRD_ARABIC_WORD"
+ * distorted output when MessageFormat gets initialized with no structured text formatter:
+ *     "first_english_word >> THIRD_ARABIC_WORD  << SECOND_ARABIC_WORD"
+ *
+ *  > mf = new MessageFormat('en', null, {"bidiStructuredText": Globalize.messageFormatter.formatters.bidiStructuredText} );
+ *  > mf.compile("FILE {0} NOT FOUND")("c:\filename.EXTENSION");
+ * structured output:
+ *     "FILE c:\filename.EXTENSION NOT FOUND"
+ * distorted output when MessageFormat gets initialized with no structured text formatter:
+ *     "FILE c:\filename.NOT FOUND EXTENSION"
+ *  */
+MessageFormat.formatters.bidiStructuredText = function( text, locale ) {
+	var strongChar = /[A-Za-z\u05d0-\u065f\u066a-\u06ef\u06fa-\u07ff\ufb1d-\ufdff\ufe70-\ufefc]/.exec( text );
+	if ( strongChar && ( strongChar[0] > "z" ) ) { //RLE + text + PDF
+		text = "'\u202B' + " + text + " + '\u202C'";
+	} else { //LRE + text + PDF
+		text = "'\u202A' + " + text + " + '\u202C'";
+	}
+	if ( /he|ar|fa/.test( locale ) ) { //RLM + text + RLM
+		return ( "'\u200F' + " + text + " + '\u200F'" );
+	} else { //LRM + text + LRM 
+		return ( "'\u200E' + " + text + " + '\u200E'" );
+	}
+};
+
 /** Enable or disable support for the default formatters, which require the
  *  `Intl` object. Note that this can't be autodetected, as the environment
  *  in which the formatted text is compiled into Javascript functions is not
@@ -259,7 +301,8 @@ MessageFormat.prototype._precompile = function(ast, data) {
     case 'messageFormatElement':
       data.pf_count = data.pf_count || 0;
       if ( ast.output ) {
-        return propname(ast.argumentIndex, 'd');
+        var ret = propname(ast.argumentIndex, 'd');
+        return this.runtime.fmt.bidiStructuredText ? this.runtime.fmt.bidiStructuredText( ret, this.lc ) : ret;
       }
       else {
         data.keys[data.pf_count] = ast.argumentIndex;

--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -1,3 +1,4 @@
+fstructur
 /** @file messageformat.js - ICU PluralFormat + SelectFormat for JavaScript
  *  @author Alex Sexton - @SlexAxton
  *  @version 0.3.0-0
@@ -133,46 +134,34 @@ MessageFormat.formatters = {
   }
 };
 
-/** Predefined number formatting function enforcing Bidi Text Direction and Structured Text by using UCC
+/** Predefined number formatting function enforcing Bidi Structured Text by using UCC
  * Prevents intermingling of text contained in placeholders with the rest of message text.
  * Maintains the integrity of Bidi text flowing according to directionality of language script.
- * Enforces 'contextual' Bidi text direction on placeholder content 
- *  i.e. text direction is defined by first strong character of placeholder text - 
- *  'right-to-left' if first strong character is bidi (Hebrew/Arabic) and 'left-to-right' othervise.
- * For reference to Bidi strucctured text see: http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text
- * For reference to Bidi text direction see: http://w3-03.ibm.com/globalization/page/publish/4353
+ * For reference to Bidi structured text see: http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text
  *  @param {string} - Placeholder text content
  *  @param {string} - Locale
  *  @returns {string} - The resultant text fixed by UCC Bidi strong marks
- *  @examples: (upper case stands for Bidi (Arabic/Hebrew) characters
+ *  @examples: (upper case stands for Bidi (Arabic/Hebrew) characters, output is shown as displayed in browser page
  *  > var MessageFormat = require('messageformat');
- *  > var mf = new MessageFormat('en', null, {"bidiStructuredText": Globalize.messageFormatter.formatters.bidiStructuredText} );
+ *  > var mf = new MessageFormat('en', null, {"bidiStructuredText": MessageFormat.formatters.bidiStructuredText} );
  *  > var mfunc = mf.compile("{0} >> {1} >> {2}");
  *  > mfunc([ "first_english_word", "SECOND_ARABIC_WORD", "THIRD_ARABIC_WORD" ])
  * structured output:
  *     "first_english_word >> SECOND_ARABIC_WORD  >> THIRD_ARABIC_WORD"
  * distorted output when MessageFormat gets initialized with no structured text formatter:
  *     "first_english_word >> THIRD_ARABIC_WORD  << SECOND_ARABIC_WORD"
- *
- *  > mf = new MessageFormat('en', null, {"bidiStructuredText": Globalize.messageFormatter.formatters.bidiStructuredText} );
- *  > mf.compile("FILE {0} NOT FOUND")("c:\filename.EXTENSION");
- * structured output:
- *     "FILE c:\filename.EXTENSION NOT FOUND"
- * distorted output when MessageFormat gets initialized with no structured text formatter:
- *     "FILE c:\filename.NOT FOUND EXTENSION"
  *  */
-MessageFormat.formatters.bidiStructuredText = function( text, locale ) {
-	var strongChar = /[A-Za-z\u05d0-\u065f\u066a-\u06ef\u06fa-\u07ff\ufb1d-\ufdff\ufe70-\ufefc]/.exec( text );
-	if ( strongChar && ( strongChar[0] > "z" ) ) { //RLE + text + PDF
-		text = "'\u202B' + " + text + " + '\u202C'";
-	} else { //LRE + text + PDF
-		text = "'\u202A' + " + text + " + '\u202C'";
-	}
-	if ( /he|ar|fa/.test( locale ) ) { //RLM + text + RLM
-		return ( "'\u200F' + " + text + " + '\u200F'" );
-	} else { //LRM + text + LRM 
-		return ( "'\u200E' + " + text + " + '\u200E'" );
-	}
+MessageFormat.formatters.bidiStructuredText = function( text, locale ) { //shensis mesage_format
+  var isLocaleRTL = function(locale) {
+    var rtlLanguages = ["ar", "fa", "he", "ks-Arab", 'pa-Arab', "ps",  "ur", "uz-Arab", "ks"];
+    return new RegExp("^" + rtlLanguages.join( "|^" ) + "$").test( locale );
+  };
+
+  if ( isLocaleRTL( locale ) ) {
+    return ( "'\u200F' + " + text + " + '\u200F'" );
+  } else {
+    return ( "'\u200E' + " + text + " + '\u200E'" );
+  }
 };
 
 /** Enable or disable support for the default formatters, which require the

--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -1,4 +1,3 @@
-fstructur
 /** @file messageformat.js - ICU PluralFormat + SelectFormat for JavaScript
  *  @author Alex Sexton - @SlexAxton
  *  @version 0.3.0-0

--- a/test/tests.js
+++ b/test/tests.js
@@ -2,7 +2,6 @@
 describe( "MessageFormat", function () {
 
   describe( "Public API", function () {
-
     it("should exist", function () {
       expect( MessageFormat ).to.be.a('function');
     });
@@ -610,6 +609,16 @@ describe( "MessageFormat", function () {
         var mf = new MessageFormat( 'en', false, {uppercase: function(v) { return v.toUpperCase(); }} );
         var mfunc = mf.compile("This is {VAR,uppercase}.");
         expect(mfunc({"VAR":"big"})).to.eql("This is BIG.");
+      });
+
+      it("should use bidiStructuredText MessageFormat formatter", function () {
+        var mf = new MessageFormat('en', null, {"bidiStructuredText": MessageFormat.formatters.bidiStructuredText} );
+        var mfunc = mf.compile("{0} >> {1}");		
+        expect(mfunc([ "first_english_word", "SECOND_ARABIC_WORD" ])).to.equal('\u200efirst_english_word\u200e >> \u200eSECOND_ARABIC_WORD\u200e');
+
+        mf = new MessageFormat('ar-EG', null, {"bidiStructuredText": MessageFormat.formatters.bidiStructuredText} );
+        var mfunc = mf.compile("{0} >> {1}");		
+        expect(mfunc([ "first_english_word", "SECOND_ARABIC_WORD" ])).to.equal('\u200ffirst_english_word\u200f >> \u200fSECOND_ARABIC_WORD\u200f');
       });
 
       it("should allow for a simple select", function () {


### PR DESCRIPTION
As per discussion under #539 Message formatting dependant on base text direction I am submitting here the addition of predefined number formatting function enforcing Bidi Text Direction and Structured Text by using UCC. The upgrading qualities are:
 * Prevents intermingling of text contained in placeholders with the rest of message text.
 * Maintains the integrity of Bidi text flowing according to directionality of language script.
 * Enforces 'contextual' Bidi text direction on placeholder content 
 *  i.e. text direction is defined by first strong character of placeholder text - 
 *  'right-to-left' if first strong character is bidi (Hebrew/Arabic) and 'left-to-right' othervise.
 * For reference to Bidi strucctured text see: http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text
 * For reference to Bidi text direction see: http://w3-03.ibm.com/globalization/page/publish/4353

Please note that this submission constitutes the first step, the next would to be step  is contribution to Globalize (https://github.com/jquery/globalize) with objective to make this Bidi formatter available for 
Globalize.messageFormatter. The intended contribution to Globalize is to:
-  add parameter (object containing formatters) to 'messageFormatter' API and pass it to 'MessageFormat'
      Globalize.prototype.messageFormatter = function( path, fmt ) { 
          ....................
          formatter = new MessageFormat( cldr.locale, pluralGenerator, fmt ).compile( message );
- expose predefined formatters
      Globalize.prototype.messageFormatter.formatters = MessageFormat.formatters;
