### PR TITLE
messageformat.js: Provide Structured Text support to MessageFormat

### DIFF
--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -16,6 +16,35 @@ function propname(key, obj) {
   }
 };
 
+/** Utility formatter function for enforcing Bidi Structured Text by using UCC
+ * Prevents intermingling of text contained in placeholders with the rest of message text.
+ * Maintains the integrity of Bidi text flowing according to directionality of language script.
+ * For reference to Bidi structured text see: http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text
+ *  @param {string} - Placeholder text content
+ *  @param {string} - Locale
+ *  @returns {string} - The resultant text fixed by UCC Bidi strong marks
+ *  @examples: (upper case stands for Bidi (Arabic/Hebrew) characters, output is shown as displayed in browser page
+ *  > var MessageFormat = require('messageformat');
+ *  > var mf = new MessageFormat('en', null, {"bidiStructuredTextFmt": true} );
+ *  > var mfunc = mf.compile("{0} >> {1} >> {2}");
+ *  > mfunc([ "first_english_word", "SECOND_ARABIC_WORD", "THIRD_ARABIC_WORD" ])
+ * structured output:
+ *     "first_english_word >> SECOND_ARABIC_WORD  >> THIRD_ARABIC_WORD"
+ * distorted output when MessageFormat gets initialized with no structured text formatter:
+ *     "first_english_word >> THIRD_ARABIC_WORD  << SECOND_ARABIC_WORD" */
+
+function bidiStructuredTextFmt( text, locale ) {
+  var isLocaleRTL = function(locale) {
+    var rtlLanguages = ["ar", "fa", "he", "ks-Arab", 'pa-Arab', "ps",  "ur", "uz-Arab", "ks"];
+    return new RegExp("^" + rtlLanguages.join( "|^" ) + "$").test( locale );
+  };
+
+  if ( isLocaleRTL( locale ) ) {
+    return ( "'\u200F' + " + text + " + '\u200F'" );
+  } else {
+    return ( "'\u200E' + " + text + " + '\u200E'" );
+  }
+};
 
 /** Create a new message formatter
  *
@@ -130,36 +159,6 @@ MessageFormat.formatters = {
       case 'short': delete o.minute;
     }
     return (new Date(v)).toLocaleTimeString(lc, o)
-  }
-};
-
-/** Predefined number formatting function enforcing Bidi Structured Text by using UCC
- * Prevents intermingling of text contained in placeholders with the rest of message text.
- * Maintains the integrity of Bidi text flowing according to directionality of language script.
- * For reference to Bidi structured text see: http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text
- *  @param {string} - Placeholder text content
- *  @param {string} - Locale
- *  @returns {string} - The resultant text fixed by UCC Bidi strong marks
- *  @examples: (upper case stands for Bidi (Arabic/Hebrew) characters, output is shown as displayed in browser page
- *  > var MessageFormat = require('messageformat');
- *  > var mf = new MessageFormat('en', null, {"bidiStructuredText": MessageFormat.formatters.bidiStructuredText} );
- *  > var mfunc = mf.compile("{0} >> {1} >> {2}");
- *  > mfunc([ "first_english_word", "SECOND_ARABIC_WORD", "THIRD_ARABIC_WORD" ])
- * structured output:
- *     "first_english_word >> SECOND_ARABIC_WORD  >> THIRD_ARABIC_WORD"
- * distorted output when MessageFormat gets initialized with no structured text formatter:
- *     "first_english_word >> THIRD_ARABIC_WORD  << SECOND_ARABIC_WORD"
- *  */
-MessageFormat.formatters.bidiStructuredText = function( text, locale ) { //shensis mesage_format
-  var isLocaleRTL = function(locale) {
-    var rtlLanguages = ["ar", "fa", "he", "ks-Arab", 'pa-Arab', "ps",  "ur", "uz-Arab", "ks"];
-    return new RegExp("^" + rtlLanguages.join( "|^" ) + "$").test( locale );
-  };
-
-  if ( isLocaleRTL( locale ) ) {
-    return ( "'\u200F' + " + text + " + '\u200F'" );
-  } else {
-    return ( "'\u200E' + " + text + " + '\u200E'" );
   }
 };
 
@@ -290,7 +289,7 @@ MessageFormat.prototype._precompile = function(ast, data) {
       data.pf_count = data.pf_count || 0;
       if ( ast.output ) {
         var ret = propname(ast.argumentIndex, 'd');
-        return this.runtime.fmt.bidiStructuredText ? this.runtime.fmt.bidiStructuredText( ret, this.lc ) : ret;
+        return this.runtime.fmt.bidiStructuredTextFmt ? bidiStructuredTextFmt( ret, this.lc ) : ret;
       }
       else {
         data.keys[data.pf_count] = ast.argumentIndex;

--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -133,6 +133,36 @@ MessageFormat.formatters = {
   }
 };
 
+/** Predefined number formatting function enforcing Bidi Structured Text by using UCC
+ * Prevents intermingling of text contained in placeholders with the rest of message text.
+ * Maintains the integrity of Bidi text flowing according to directionality of language script.
+ * For reference to Bidi structured text see: http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text
+ *  @param {string} - Placeholder text content
+ *  @param {string} - Locale
+ *  @returns {string} - The resultant text fixed by UCC Bidi strong marks
+ *  @examples: (upper case stands for Bidi (Arabic/Hebrew) characters, output is shown as displayed in browser page
+ *  > var MessageFormat = require('messageformat');
+ *  > var mf = new MessageFormat('en', null, {"bidiStructuredText": MessageFormat.formatters.bidiStructuredText} );
+ *  > var mfunc = mf.compile("{0} >> {1} >> {2}");
+ *  > mfunc([ "first_english_word", "SECOND_ARABIC_WORD", "THIRD_ARABIC_WORD" ])
+ * structured output:
+ *     "first_english_word >> SECOND_ARABIC_WORD  >> THIRD_ARABIC_WORD"
+ * distorted output when MessageFormat gets initialized with no structured text formatter:
+ *     "first_english_word >> THIRD_ARABIC_WORD  << SECOND_ARABIC_WORD"
+ *  */
+MessageFormat.formatters.bidiStructuredText = function( text, locale ) { //shensis mesage_format
+  var isLocaleRTL = function(locale) {
+    var rtlLanguages = ["ar", "fa", "he", "ks-Arab", 'pa-Arab', "ps",  "ur", "uz-Arab", "ks"];
+    return new RegExp("^" + rtlLanguages.join( "|^" ) + "$").test( locale );
+  };
+
+  if ( isLocaleRTL( locale ) ) {
+    return ( "'\u200F' + " + text + " + '\u200F'" );
+  } else {
+    return ( "'\u200E' + " + text + " + '\u200E'" );
+  }
+};
+
 /** Enable or disable support for the default formatters, which require the
  *  `Intl` object. Note that this can't be autodetected, as the environment
  *  in which the formatted text is compiled into Javascript functions is not
@@ -259,7 +289,8 @@ MessageFormat.prototype._precompile = function(ast, data) {
     case 'messageFormatElement':
       data.pf_count = data.pf_count || 0;
       if ( ast.output ) {
-        return propname(ast.argumentIndex, 'd');
+        var ret = propname(ast.argumentIndex, 'd');
+        return this.runtime.fmt.bidiStructuredText ? this.runtime.fmt.bidiStructuredText( ret, this.lc ) : ret;
       }
       else {
         data.keys[data.pf_count] = ast.argumentIndex;

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   },
   "scripts": {
     "test": "make test"
+  },
+  "browser": {
+    "fs": false
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -2,7 +2,6 @@
 describe( "MessageFormat", function () {
 
   describe( "Public API", function () {
-
     it("should exist", function () {
       expect( MessageFormat ).to.be.a('function');
     });
@@ -610,6 +609,16 @@ describe( "MessageFormat", function () {
         var mf = new MessageFormat( 'en', false, {uppercase: function(v) { return v.toUpperCase(); }} );
         var mfunc = mf.compile("This is {VAR,uppercase}.");
         expect(mfunc({"VAR":"big"})).to.eql("This is BIG.");
+      });
+
+      it("should use bidiStructuredText MessageFormat formatter", function () {
+        var mf = new MessageFormat('en', null, {"bidiStructuredText": MessageFormat.formatters.bidiStructuredText} );
+        var mfunc = mf.compile("{0} >> {1}");		
+        expect(mfunc([ "first_english_word", "SECOND_ARABIC_WORD" ])).to.equal('\u200efirst_english_word\u200e >> \u200eSECOND_ARABIC_WORD\u200e');
+
+        mf = new MessageFormat('ar-EG', null, {"bidiStructuredText": MessageFormat.formatters.bidiStructuredText} );
+        var mfunc = mf.compile("{0} >> {1}");		
+        expect(mfunc([ "first_english_word", "SECOND_ARABIC_WORD" ])).to.equal('\u200ffirst_english_word\u200f >> \u200fSECOND_ARABIC_WORD\u200f');
       });
 
       it("should allow for a simple select", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -2,6 +2,7 @@
 describe( "MessageFormat", function () {
 
   describe( "Public API", function () {
+
     it("should exist", function () {
       expect( MessageFormat ).to.be.a('function');
     });
@@ -611,14 +612,14 @@ describe( "MessageFormat", function () {
         expect(mfunc({"VAR":"big"})).to.eql("This is BIG.");
       });
 
-      it("should use bidiStructuredText MessageFormat formatter", function () {
-        var mf = new MessageFormat('en', null, {"bidiStructuredText": MessageFormat.formatters.bidiStructuredText} );
+      it("should use bidiStructuredTextFmt MessageFormat formatter", function () {
+        var mf = new MessageFormat('en', null, {"bidiStructuredTextFmt": true} );
         var mfunc = mf.compile("{0} >> {1}");		
-        expect(mfunc([ "first_english_word", "SECOND_ARABIC_WORD" ])).to.equal('\u200efirst_english_word\u200e >> \u200eSECOND_ARABIC_WORD\u200e');
+        expect(mfunc([ "Hello! English", "Hello \u0647\u0644\u0627\u060d" ])).to.equal('\u200eHello! English\u200e >> \u200eHello \u0647\u0644\u0627\u060d\u200e');
 
-        mf = new MessageFormat('ar-EG', null, {"bidiStructuredText": MessageFormat.formatters.bidiStructuredText} );
+        mf = new MessageFormat('ar-EG', null, {"bidiStructuredTextFmt": true} );
         var mfunc = mf.compile("{0} >> {1}");		
-        expect(mfunc([ "first_english_word", "SECOND_ARABIC_WORD" ])).to.equal('\u200ffirst_english_word\u200f >> \u200fSECOND_ARABIC_WORD\u200f');
+        expect(mfunc([ "Hello! English", "Hello \u0647\u0644\u0627\u060d" ])).to.equal('\u200fHello! English\u200f >> \u200fHello \u0647\u0644\u0627\u060d\u200f');
       });
 
       it("should allow for a simple select", function () {


### PR DESCRIPTION
Submitted here is the addition of predefined message formatting function enforcing Biid Structured Text by using UCC. The upgrading qualities are:
 - Prevents intermingling of text contained in placeholders with the rest of message text.
 - Maintains the integrity of Bidi text flowing according to directionality of language script.
For reference to Bidi structured text see: http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text

Please note that this submission constitutes the first step, the next would to be step is contribution to Globalize (https://github.com/jquery/globalize) with objective to make this Bidi formatter available for
Globalize.messageFormatter. The intended contribution to Globalize is to:

add parameter (object containing formatters) to 'messageFormatter' API and pass it to 'MessageFormat' 
Globalize.prototype.messageFormatter = function( path, fmt ) { 
      .................... 
      formatter = new MessageFormat( cldr.locale, pluralGenerator, fmt ).compile( message );