### PR TITLE
Added support for compiling more deeply nested namespaces

### DIFF
--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -490,6 +490,18 @@ MessageFormat.prototype.compile = function ( messages, opt ) {
         for (var i = 0; i < level; ++i) indent += '  ';
         for (var k in r) o.push('\n' + indent + '  ' + propname(k) + ': ' + stringify(r[k], level + 1));
         return '{' + o.join(',') + '\n' + indent + '}';
+      },
+      recurseNs = function(self, messages, ns, r, baseNs) {
+        if (typeof messages[ns] == 'string') {
+          try { r[ns] = compileMsg(self, messages[ns]); }
+          catch (e) { e.message = e.message.replace(':', ' with `' + ns + '`' + (baseNs ? ' in `' + baseNs + '`' : '') + ':'); throw e; }
+        } else {
+          baseNs = baseNs ? ns : (baseNs + '.' + ns);
+          r[ns] = {};
+          for (var key in messages[ns]) {
+            recurseNs(self, messages[ns], key, r[ns], baseNs);
+          }
+        }
       };
 
   if (typeof messages == 'string') {
@@ -504,16 +516,7 @@ MessageFormat.prototype.compile = function ( messages, opt ) {
 
   for (var ns in messages) {
     if (opt.locale) this.lc = opt.locale[ns] && [].concat(opt.locale[ns]) || lc0;
-    if (typeof messages[ns] == 'string') {
-      try { r[ns] = compileMsg(this, messages[ns]); }
-      catch (e) { e.message = e.message.replace(':', ' with `' + ns + '`:'); throw e; }
-    } else {
-      r[ns] = {};
-      for (var key in messages[ns]) {
-        try { r[ns][key] = compileMsg(this, messages[ns][key]); }
-        catch (e) { e.message = e.message.replace(':', ' with `' + key + '` in `' + ns + '`:'); throw e; }
-      }
-    }
+    recurseNs(this, messages, ns, r, '');
   }
 
   this.lc = lc0;


### PR DESCRIPTION
I'm working on an system that uses more levels of namespaces than are currently supported by the compile function. This change adds support for any arbitrary depth of namespace nesting by using a recursive function to handle them instead of the current nested for loops.

### Example:
```
var messages = {
  namespace1: {
    namespace2: {
      message: "Compile can't handle this without this change!"
    }
  }
}

var MessageFormat = require('messageformat');
var messageformat = new MessageFormat();
var compiled = messageformat.compile(messages);
```

Results in the error:

> Warning: Parser error with `namespace2` in `namespace1`: TypeError: Object #<Object> has no method 'charCodeAt' Use --force to continue.