### PR TITLE
Enclose JavaScript reserved words used as keys in quotes

### DIFF
--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -8,18 +8,17 @@
 /** Utility function for quoting an Object's key value iff required
  *  @private  */
 function propname(key, obj) {
-  var name = '';
-  try {
-    if (/^[A-Z_$][0-9A-Z_$]*$/i.test(key) && new Function(key, '')) {
-      name = obj ? obj + '.' + key : key;
-    }
-  } catch (e) {
-  } finally {
-    if (!name) {
-      var jkey = JSON.stringify(key);
-      name = obj ? obj + '[' + jkey + ']' : jkey;
-    }
-    return name;
+  /* Quote the key if it contains invalid characters or is an
+   * ECMAScript 3rd Edition reserved word.
+   */
+  if (/^[A-Z_$][0-9A-Z_$]*$/i.test(key) &&
+     ['break', 'continue', 'delete', 'else', 'for', 'function', 'if', 'in', 'new',
+      'return', 'this', 'typeof', 'var', 'void', 'while', 'with', 'case', 'catch',
+      'default', 'do', 'finally', 'instanceof', 'switch', 'throw', 'try'].indexOf(key) < 0) {
+    return obj ? obj + '.' + key : key;
+  } else {
+    var jkey = JSON.stringify(key);
+    return obj ? obj + '[' + jkey + ']' : jkey;
   }
 }
 

--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -8,9 +8,12 @@
 /** Utility function for quoting an Object's key value iff required
  *  @private  */
 function propname(key, obj) {
-  if (/^[A-Z_$][0-9A-Z_$]*$/i.test(key)) {
-    return obj ? obj + '.' + key : key;
-  } else {
+  try {
+    if (/^[A-Z_$][0-9A-Z_$]*$/i.test(key) && new Function(key, '')) {
+      return obj ? obj + '.' + key : key;
+    }
+  } catch (e) {
+  } finally {
     var jkey = JSON.stringify(key);
     return obj ? obj + '[' + jkey + ']' : jkey;
   }

--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -8,14 +8,18 @@
 /** Utility function for quoting an Object's key value iff required
  *  @private  */
 function propname(key, obj) {
+  var name = '';
   try {
     if (/^[A-Z_$][0-9A-Z_$]*$/i.test(key) && new Function(key, '')) {
-      return obj ? obj + '.' + key : key;
+      name = obj ? obj + '.' + key : key;
     }
   } catch (e) {
   } finally {
-    var jkey = JSON.stringify(key);
-    return obj ? obj + '[' + jkey + ']' : jkey;
+    if (!name) {
+      var jkey = JSON.stringify(key);
+      name = obj ? obj + '[' + jkey + ']' : jkey;
+    }
+    return name;
   }
 }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -811,14 +811,20 @@ describe( "MessageFormat", function () {
 
       it("can compile an object enclosing reserved JavaScript words used as keys in quotes", function () {
         var mf = new MessageFormat( 'en' );
-        var data = { 'default': 'I have {FRIENDS, plural, one{one friend} other{# friends}}.' };
+        var data = { 'default': 'I have {FRIENDS, plural, one{one friend} other{# friends}}.',
+                     'unreserved': 'I have {FRIENDS, plural, one{one friend} other{# friends}}.' };
         var mfunc = mf.compile(data);
         expect(mfunc).to.be.a('function');
         expect(mfunc.toString()).to.match(/"default"/);
+        expect(mfunc.toString()).to.match(/[^"]unreserved[^"]/);
 
         expect(mfunc()['default']).to.be.a('function');
         expect(mfunc()['default']({FRIENDS:1})).to.eql("I have one friend.");
         expect(mfunc()['default']({FRIENDS:2})).to.eql("I have 2 friends.");
+
+        expect(mfunc().unreserved).to.be.a('function');
+        expect(mfunc().unreserved({FRIENDS:1})).to.eql("I have one friend.");
+        expect(mfunc().unreserved({FRIENDS:2})).to.eql("I have 2 friends.");
       });
     });
   });

--- a/test/tests.js
+++ b/test/tests.js
@@ -808,6 +808,18 @@ describe( "MessageFormat", function () {
         expect(mfunc().key({FRIENDS:1})).to.eql("I have one friend.");
         expect(mfunc().key({FRIENDS:2})).to.eql("I have 2 friends.");
       });
+
+      it("can compile an object enclosing reserved JavaScript words used as keys in quotes", function () {
+        var mf = new MessageFormat( 'en' );
+        var data = { 'default': 'I have {FRIENDS, plural, one{one friend} other{# friends}}.' };
+        var mfunc = mf.compile(data);
+        expect(mfunc).to.be.a('function');
+        expect(mfunc.toString()).to.match(/"default"/);
+
+        expect(mfunc()['default']).to.be.a('function');
+        expect(mfunc()['default']({FRIENDS:1})).to.eql("I have one friend.");
+        expect(mfunc()['default']({FRIENDS:2})).to.eql("I have 2 friends.");
+      });
     });
   });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -811,20 +811,18 @@ describe( "MessageFormat", function () {
 
       it("can compile an object enclosing reserved JavaScript words used as keys in quotes", function () {
         var mf = new MessageFormat( 'en' );
-        var data = { 'default': 'I have {FRIENDS, plural, one{one friend} other{# friends}}.',
-                     'unreserved': 'I have {FRIENDS, plural, one{one friend} other{# friends}}.' };
+        var data = { 'default': 'default is a JavaScript reserved word so should be quoted',
+                     'unreserved': 'unreserved is not a JavaScript reserved word so should not be quoted' };
         var mfunc = mf.compile(data);
         expect(mfunc).to.be.a('function');
         expect(mfunc.toString()).to.match(/"default"/);
         expect(mfunc.toString()).to.match(/[^"]unreserved[^"]/);
 
         expect(mfunc()['default']).to.be.a('function');
-        expect(mfunc()['default']({FRIENDS:1})).to.eql("I have one friend.");
-        expect(mfunc()['default']({FRIENDS:2})).to.eql("I have 2 friends.");
+        expect(mfunc()['default']()).to.eql("default is a JavaScript reserved word so should be quoted");
 
         expect(mfunc().unreserved).to.be.a('function');
-        expect(mfunc().unreserved({FRIENDS:1})).to.eql("I have one friend.");
-        expect(mfunc().unreserved({FRIENDS:2})).to.eql("I have 2 friends.");
+        expect(mfunc().unreserved()).to.eql("unreserved is not a JavaScript reserved word so should not be quoted");
       });
     });
   });


### PR DESCRIPTION
When compiled objects use JavaScript reserved words as keys they are not being enclosed in quotes which causes errors in IE <= 8. This change corrects the problem.

### Example:
In this example the JavaScript reserved word `default` is used as a key.
```
var messages = {
  default: "IE <= 8 can't load the compiled script because 'default' is a reserved word in JavaScript"
}

var MessageFormat = require('messageformat');
var messageformat = new MessageFormat();
var compiled = messageformat.compile(messages);

compiled.toString();
```
### Output:
```
function anonymous() {
var number = function (value, offset) {
  if (isNaN(value)) throw new Error("'" + value + "' isn't a number.");
  return value - (offset || 0);
};
var plural = function (value, offset, lcfunc, data, isOrdinal) {
  if ({}.hasOwnProperty.call(data, value)) return data[value]();
  if (offset) value -= offset;
  var key = lcfunc(value, isOrdinal);
  if (key in data) return data[key]();
  return data.other();
};
var select = function (value, data) {
  if ({}.hasOwnProperty.call(data, value)) return data[value]();
  return data.other()
};
var pluralFuncs = {
  en: function (n, ord) {
    var s = String(n).split('.'), v0 = !s[1], t0 = Number(s[0]) == n,
        n10 = t0 && s[0].slice(-1), n100 = t0 && s[0].slice(-2);
    if (ord) return (n10 == 1 && n100 != 11) ? 'one'
        : (n10 == 2 && n100 != 12) ? 'two'
        : (n10 == 3 && n100 != 13) ? 'few'
        : 'other';
    return (n == 1 && v0) ? 'one' : 'other';
  }
};
var fmt = {};

return {
  default: function(d) { return "IE <= 8 can't load the compiled script because 'default' is a reserved word in JavaScript"; }
}
}

```
### Results in error in IE<=8
>  "Expected identifier, string or number"