### PR TITLE
Remove component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,9 +1,0 @@
-{
-  "name": "messageformat",
-  "repo": "SlexAxton/messageformat.js",
-  "author": "Alex Sexton <alexsexton@gmail.com>",
-  "description": "PluralFormat and SelectFormat Message and i18n Tool - A JavaScript Implemenation of the ICU standards.",
-  "version": "0.3.1",
-  "scripts": ["messageformat.js"],
-  "main": "messageformat.js"
-}


### PR DESCRIPTION
We should deprecate support for component, as it [is no longer maintained](/componentjs/component/issues/639). Also, I at least wasn't able to find messageformat on [component.github.io](http://component.github.io/), and component.io appears to longer be operational.