### PR TITLE
Update watchr dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "glob": "~6.0.4",
     "make-plural": "~3.0.3",
     "nopt": "~3.0.6",
-    "watchr": "~2.4.13"
+    "watchr": "^2.5.0"
   },
   "devDependencies": {
     "browserify": "~13.0.0",


### PR DESCRIPTION
A dep of watchr is causing installs to fail, as per https://github.com/bevry/typechecker/issues/13

I've released v2.5.0 of watchr, so this will need to be updated. Watchr follows semver, so changed ~ to ^