### PR TITLE
Restore better error message for missing argument referenced with '#' in plural rule

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -128,7 +128,7 @@ Compiler.prototype.token = function(token, plural) {
     case 'octothorpe':
       if (!plural) return '"#"';
       fn = 'number';
-      args = [ Compiler.propname(plural.arg, 'd') ];
+      args = [ Compiler.propname(plural.arg, 'd'), JSON.stringify(plural.arg) ];
       if (plural.offset) args.push(plural.offset);
       this.runtime.number = true;
       break;

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,10 +211,11 @@ MessageFormat.runtime = {
   /** Utility function for `#` in plural rules
    *
    * @param {number} value - The value to operate on
+   * @param {string} argumentName - The name of the argument containing `value`
    * @param {number} [offset=0] - An optional offset, set by the surrounding context
    */
-  number: function(value, offset) {
-    if (isNaN(value)) throw new Error("'" + value + "' isn't a number.");
+  number: function(value, argumentName, offset) {
+    if (isNaN(value)) throw new Error("'" + value + "' from argument '" + argumentName + "' isn't a number.");
     return value - (offset || 0);
   },
 

--- a/test/messageformat.js
+++ b/test/messageformat.js
@@ -289,9 +289,9 @@ describe("Basic Message Formatting", function() {
       "I have {FRIENDS, plural, one{one friend} other{# friends but {ENEMIES, plural, one{one enemy} other{# enemies}}}}."
     );
     expect(mfunc({FRIENDS:0, ENEMIES: 0})).to.eql("I have 0 friends but 0 enemies.");
-    expect(function(){ var x = mfunc({FRIENDS:0,ENEMIES:'none'}); }).to.throwError(/ isn't a number\.$/);
-    expect(function(){ var x = mfunc({}); }).to.throwError(/ isn't a number\.$/);
-    expect(function(){ var x = mfunc({ENEMIES:0}); }).to.throwError(/ isn't a number\.$/);
+    expect(function(){ var x = mfunc({FRIENDS:0,ENEMIES:'none'}); }).to.throwError(/\'ENEMIES\' isn't a number\.$/);
+    expect(function(){ var x = mfunc({}); }).to.throwError(/\'.+\' isn't a number\.$/);
+    expect(function(){ var x = mfunc({ENEMIES:0}); }).to.throwError(/\'FRIENDS\' isn't a number\.$/);
   });
 
   it("should not expose prototype members - selects", function() {


### PR DESCRIPTION
Removed in a005b99561012510885cca61ba89864af83d9c3b