### PR TITLE
Add configuration option to specify the input file's encoding to cli/messageformat.js

### DIFF
--- a/cli/messageformat.js
+++ b/cli/messageformat.js
@@ -12,6 +12,7 @@ const glob = require('glob');
 const MessageFormat = require('messageformat');
 const nopt = require('nopt');
 const path = require('path');
+const uv = require('uv');
 
 const knownOpts = {
   delimiters: [String, Array],
@@ -149,7 +150,8 @@ function readInput(include, extensions, sep) {
           case '.prefs':
           case '.pro':
           case '.properties':
-            const src = fs.readFileSync(fn, 'latin1');
+            const raw = fs.readFileSync(fn);
+            const src = raw.toString(uv(raw) ? 'utf8' : 'latin1');
             root[part] = dotProperties.parse(src, sep.test('.'))
             break
           default:

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "dot-properties": "^0.2.0",
     "glob": "~7.0.6",
-    "nopt": "~3.0.6"
+    "nopt": "~3.0.6",
+    "uv": "^1.0.7"
   },
   "peerDependencies": {
     "messageformat": "2.x"


### PR DESCRIPTION
This PR adds a configuration option to specify the encoding that is used to read the input file. The default for that option remains 'latin1'.

For reference: since Java 9 properties files are loaded in UTF-8 encoding, see https://docs.oracle.com/javase/9/intl/internationalization-enhancements-jdk-9.htm for details.
