### PR TITLE
Fix package repo paths

### DIFF
--- a/mf1/packages/cli/package.json
+++ b/mf1/packages/cli/package.json
@@ -17,7 +17,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/cli"
+    "directory": "mf1/packages/cli"
   },
   "bin": {
     "messageformat": "cli.js"

--- a/mf1/packages/convert/package.json
+++ b/mf1/packages/convert/package.json
@@ -15,7 +15,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/convert"
+    "directory": "mf1/packages/convert"
   },
   "main": "index.js",
   "engines": {

--- a/mf1/packages/core/package.json
+++ b/mf1/packages/core/package.json
@@ -20,7 +20,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/core"
+    "directory": "mf1/packages/core"
   },
   "main": "lib/messageformat.js",
   "browser": "./messageformat.js",

--- a/mf1/packages/date-skeleton/package.json
+++ b/mf1/packages/date-skeleton/package.json
@@ -18,7 +18,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/date-skeleton"
+    "directory": "mf1/packages/date-skeleton"
   },
   "files": [
     "lib/"

--- a/mf1/packages/number-skeleton/package.json
+++ b/mf1/packages/number-skeleton/package.json
@@ -18,7 +18,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/number-skeleton"
+    "directory": "mf1/packages/number-skeleton"
   },
   "files": [
     "lib/"

--- a/mf1/packages/parser/package.json
+++ b/mf1/packages/parser/package.json
@@ -18,7 +18,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/parser"
+    "directory": "mf1/packages/parser"
   },
   "type": "commonjs",
   "main": "lib/parser.js",

--- a/mf1/packages/react/package.json
+++ b/mf1/packages/react/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/react"
+    "directory": "mf1/packages/react"
   },
   "keywords": [
     "i18n",

--- a/mf1/packages/rollup-plugin/package.json
+++ b/mf1/packages/rollup-plugin/package.json
@@ -21,7 +21,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/rollup-plugin"
+    "directory": "mf1/packages/rollup-plugin"
   },
   "main": "lib/index.js",
   "files": [

--- a/mf1/packages/runtime/package.json
+++ b/mf1/packages/runtime/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/runtime"
+    "directory": "mf1/packages/runtime"
   },
   "files": [
     "esm/",

--- a/mf1/packages/webpack-loader/package.json
+++ b/mf1/packages/webpack-loader/package.json
@@ -23,7 +23,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/webpack-loader"
+    "directory": "mf1/packages/webpack-loader"
   },
   "main": "index.js",
   "dependencies": {

--- a/mf2/fluent/package.json
+++ b/mf2/fluent/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/mf2-fluent"
+    "directory": "mf2/fluent"
   },
   "main": "lib/index.js",
   "type": "module",

--- a/mf2/icu-messageformat-1/package.json
+++ b/mf2/icu-messageformat-1/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/mf2-icu-mf1"
+    "directory": "mf2/icu-messageformat-1"
   },
   "main": "lib/index.js",
   "type": "module",

--- a/mf2/messageformat/package.json
+++ b/mf2/messageformat/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/mf2-messageformat"
+    "directory": "mf2/messageformat"
   },
   "main": "lib/index.js",
   "type": "module",

--- a/mf2/resource/package.json
+++ b/mf2/resource/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/mf2-resource"
+    "directory": "mf2/resource"
   },
   "main": "lib/index.js",
   "files": [

--- a/mf2/xliff/package.json
+++ b/mf2/xliff/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/messageformat/messageformat.git",
-    "directory": "packages/xliff"
+    "directory": "mf2/xliff"
   },
   "main": "lib/index.js",
   "type": "module",


### PR DESCRIPTION
Looks like these were [moved](https://github.com/messageformat/messageformat/commit/17025e84062e50050310a337b1ab852bddd18747) a little while back but the repo paths were missed.