### PR TITLE
Apply updates to match LDML 48.2 spec

### DIFF
--- a/mf2/fluent/src/fluent-to-resource.ts
+++ b/mf2/fluent/src/fluent-to-resource.ts
@@ -16,7 +16,7 @@ import type {
  * Compile a Fluent resource (i.e. an FTL file) into a Map of
  * {@link MessageFormat} instances.
  *
- * Uses {@link DraftFunctions.currency}, {@link DraftFunctions.unit}, as well as
+ * In addition to default functions, uses {@link DraftFunctions.unit} as well as
  * a custom `fluent:message` function provided by {@link getMessageFunction}.
  *
  * @param source - A Fluent resource,
@@ -37,7 +37,6 @@ export function fluentToResource(
   const { detectNumberSelection, ...opt } = options ?? {};
   opt.functions = Object.assign(
     {
-      currency: DraftFunctions.currency,
       datetime: DraftFunctions.datetime,
       unit: DraftFunctions.unit,
       'fluent:message': getMessageFunction(res)

--- a/mf2/fluent/src/message-to-fluent.ts
+++ b/mf2/fluent/src/message-to-fluent.ts
@@ -155,7 +155,7 @@ function functionRefToFluent(
   if (entries?.length) {
     args.named = [];
     for (const [name, value] of entries) {
-      if (name === 'u:dir' || name === 'u:locale') {
+      if (name === 'u:dir') {
         throw new Error(`The option "${name}" is not supported in Fluent`);
       }
       const va = valueToFluent(ctx, value);

--- a/mf2/icu-messageformat-1/src/functions.ts
+++ b/mf2/icu-messageformat-1/src/functions.ts
@@ -25,7 +25,7 @@ function currency(
   checkArgStyle(ctx, options);
   const scale = Number(options['mf1:scale']);
   if (scale && scale !== 1) operand = scale * Number(operand);
-  return DraftFunctions.currency(ctx, options, operand);
+  return DefaultFunctions.currency(ctx, options, operand);
 }
 
 function date(
@@ -150,7 +150,7 @@ function unit(
  */
 export let MF1Functions = {
   /**
-   * A wrapper around {@link DraftFunctions.currency},
+   * A wrapper around {@link DefaultFunctions.currency},
    * used for formatting a `number, currency` and `number, ::currency` placeholder.
    */
   'mf1:currency': currency,

--- a/mf2/messageformat/README.md
+++ b/mf2/messageformat/README.md
@@ -4,13 +4,13 @@ the new standard for localization developed by the [MessageFormat Working Group]
 This includes a formatter that can be used as a polyfill for
 the proposed [ECMA-402 Intl.MessageFormat] formatter.
 
-The API provided by this library is current as of the [LDML 48] (October 2025)
-version of the MF2 specification.
+The API provided by this library is current as of the [LDML 48.2][ldml] (March 2026)
+version of the Unicode MessageFormat specification.
 
 [unicode messageformat 2.0]: https://unicode.org/reports/tr35/tr35-messageFormat.html
 [messageformat working group]: https://github.com/unicode-org/message-format-wg
 [ecma-402 intl.messageformat ]: https://github.com/tc39/proposal-intl-messageformat/
-[ldml 48]: https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html
+[ldml]: https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html
 
 ```sh
 npm install --save messageformat

--- a/mf2/messageformat/src/functions/index.ts
+++ b/mf2/messageformat/src/functions/index.ts
@@ -33,12 +33,12 @@ import { unit } from './unit.ts';
 
 /**
  * Functions classified as REQUIRED by the
- * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#contents-of-part-9-messageformat | LDML 48 MessageFormat specification}.
+ * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#contents-of-part-9-messageformat | LDML 48.2 MessageFormat specification}.
  */
 export let DefaultFunctions = {
   /**
-   * Supports formatting as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-currency-function | :currency function}.
+   * Supports formatting as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-currency-function | :currency function}.
    *
    * The `operand` must be a number, BigInt, or string representing a JSON number,
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
@@ -48,8 +48,8 @@ export let DefaultFunctions = {
   currency,
 
   /**
-   * Supports formatting and selection as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-integer-function | :integer function}.
+   * Supports formatting and selection as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-integer-function | :integer function}.
    *
    * The `operand` must be a number, BigInt, or string representing a JSON number,
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
@@ -57,8 +57,8 @@ export let DefaultFunctions = {
   integer,
 
   /**
-   * Supports formatting and selection as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-number-function | :number function}.
+   * Supports formatting and selection as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-number-function | :number function}.
    *
    * The `operand` must be a number, BigInt, or string representing a JSON number,
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
@@ -66,8 +66,8 @@ export let DefaultFunctions = {
   number,
 
   /**
-   * Supports formatting and selection as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-offset-function | :offset function}.
+   * Supports formatting and selection as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-offset-function | :offset function}.
    *
    * The `operand` must be a number, BigInt, or string representing a JSON number,
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
@@ -75,8 +75,8 @@ export let DefaultFunctions = {
   offset,
 
   /**
-   * Supports formatting as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-percent-function | :percent function}.
+   * Supports formatting as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-percent-function | :percent function}.
    *
    * The `operand` must be a number, BigInt, or string representing a JSON number,
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
@@ -84,8 +84,8 @@ export let DefaultFunctions = {
   percent,
 
   /**
-   * Supports formatting and selection as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-string-function | :string function}.
+   * Supports formatting and selection as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-string-function | :string function}.
    *
    * The `operand` must be a stringifiable value.
    * An `undefined` value is resolved as an empty string.
@@ -98,7 +98,7 @@ DefaultFunctions = Object.freeze(
 
 /**
  * Functions classified as DRAFT by the
- * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#contents-of-part-9-messageformat | LDML 48 MessageFormat specification}.
+ * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#contents-of-part-9-messageformat | LDML 48.2 MessageFormat specification}.
  *
  * These are liable to change, and are **_not_** covered by any stability guarantee.
  *
@@ -113,8 +113,8 @@ DefaultFunctions = Object.freeze(
  */
 export let DraftFunctions = {
   /**
-   * Supports formatting as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-date-function | :date function}.
+   * Supports formatting as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-date-function | :date function}.
    *
    * The `operand` must be a Date, number, or string representing a date,
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
@@ -122,8 +122,8 @@ export let DraftFunctions = {
   date,
 
   /**
-   * Supports formatting as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-datetime-function | :datetime function}.
+   * Supports formatting as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-datetime-function | :datetime function}.
    *
    * The `operand` must be a Date, number, or string representing a date,
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
@@ -131,8 +131,8 @@ export let DraftFunctions = {
   datetime,
 
   /**
-   * Supports formatting as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-time-function | :time function}.
+   * Supports formatting as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-time-function | :time function}.
    *
    * The `operand` must be a Date, number, or string representing a date,
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
@@ -140,8 +140,8 @@ export let DraftFunctions = {
   time,
 
   /**
-   * Supports formatting as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-unit-function | :unit function}.
+   * Supports formatting as defined in LDML 48.2 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#the-unit-function | :unit function}.
    *
    * The `operand` must be a number, BigInt, or string representing a JSON number,
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.

--- a/mf2/messageformat/src/functions/index.ts
+++ b/mf2/messageformat/src/functions/index.ts
@@ -37,6 +37,17 @@ import { unit } from './unit.ts';
  */
 export let DefaultFunctions = {
   /**
+   * Supports formatting as defined in LDML 48 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-currency-function | :currency function}.
+   *
+   * The `operand` must be a number, BigInt, or string representing a JSON number,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   *
+   * The `currency` option must be provided by either the operand's `options` or the `exprOpt` expression options.
+   */
+  currency,
+
+  /**
    * Supports formatting and selection as defined in LDML 48 for the
    * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-integer-function | :integer function}.
    *
@@ -62,6 +73,15 @@ export let DefaultFunctions = {
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
    */
   offset,
+
+  /**
+   * Supports formatting as defined in LDML 48 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-percent-function | :percent function}.
+   *
+   * The `operand` must be a number, BigInt, or string representing a JSON number,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   */
+  percent,
 
   /**
    * Supports formatting and selection as defined in LDML 48 for the
@@ -94,17 +114,6 @@ DefaultFunctions = Object.freeze(
 export let DraftFunctions = {
   /**
    * Supports formatting as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-currency-function | :currency function}.
-   *
-   * The `operand` must be a number, BigInt, or string representing a JSON number,
-   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
-   *
-   * The `currency` option must be provided by either the operand's `options` or the `exprOpt` expression options.
-   */
-  currency,
-
-  /**
-   * Supports formatting as defined in LDML 48 for the
    * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-date-function | :date function}.
    *
    * The `operand` must be a Date, number, or string representing a date,
@@ -120,15 +129,6 @@ export let DraftFunctions = {
    * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
    */
   datetime,
-
-  /**
-   * Supports formatting as defined in LDML 48 for the
-   * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#the-percent-function | :percent function}.
-   *
-   * The `operand` must be a number, BigInt, or string representing a JSON number,
-   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
-   */
-  percent,
 
   /**
    * Supports formatting as defined in LDML 48 for the

--- a/mf2/messageformat/src/messageformat.ts
+++ b/mf2/messageformat/src/messageformat.ts
@@ -76,7 +76,7 @@ export interface MessageFormatOptions<
 
 /**
  * A message formatter for that implements the
- * {@link https://www.unicode.org/reports/tr35/tr35-76/tr35-messageFormat.html#contents-of-part-9-messageformat | LDML 48 MessageFormat}
+ * {@link https://www.unicode.org/reports/tr35/tr35-78/tr35-messageFormat.html#contents-of-part-9-messageformat | LDML 48.2 MessageFormat}
  * specification as well as the {@link https://github.com/tc39/proposal-intl-messageformat/ | TC39 Intl.MessageFormat proposal}.
  *
  * @category Formatting

--- a/mf2/messageformat/src/spec.test.ts
+++ b/mf2/messageformat/src/spec.test.ts
@@ -19,7 +19,8 @@ import {
   visit
 } from './index.ts';
 
-const skipTags = new Set(['u:locale']);
+// Use to declare test tags for unsupported features
+const skipTags = new Set();
 
 const tests = (tc: Test) => () => {
   const functions = { ...DraftFunctions, ...TestFunctions };


### PR DESCRIPTION
Applies the following upstream spec changes:
- unicode-org/message-format-wg#1100
- unicode-org/message-format-wg#1101
- unicode-org/message-format-wg#1102