### PR TITLE
Update to TypeScript 6

### DIFF
--- a/mf1/packages/core/rollup.config.mjs
+++ b/mf1/packages/core/rollup.config.mjs
@@ -37,8 +37,7 @@ const browserBundle = {
     resolve(),
     commonjs(),
     typescript({
-      downlevelIteration: true,
-      target: 'ES5'
+      target: 'ES2017'
     }),
     babel({
       babelHelpers: 'bundled',

--- a/mf1/packages/core/tsconfig.declarations.json
+++ b/mf1/packages/core/tsconfig.declarations.json
@@ -2,9 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationDir": "lib",
+    "declarationDir": "./lib",
     "emitDeclarationOnly": true,
-    "removeComments": false
+    "removeComments": false,
+    "rootDir": "./src"
   },
   "exclude": ["**/*.test.ts", "**/api.d.ts"]
 }

--- a/mf1/packages/core/tsconfig.json
+++ b/mf1/packages/core/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "removeComments": true
   },
   "include": ["src/*"],

--- a/mf1/packages/date-skeleton/tsconfig.build.json
+++ b/mf1/packages/date-skeleton/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
-    "outDir": "lib"
+    "outDir": "./lib",
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts"]

--- a/mf1/packages/number-skeleton/src/numberformat/options.ts
+++ b/mf1/packages/number-skeleton/src/numberformat/options.ts
@@ -285,7 +285,7 @@ export function getNumberFormatOptions(
       opt.signDisplay = 'negative';
       break;
     default:
-      if (sign) fail(sign);
+      if (sign) onError(sign);
   }
 
   switch (roundingMode) {

--- a/mf1/packages/number-skeleton/tsconfig.build.json
+++ b/mf1/packages/number-skeleton/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
-    "outDir": "lib"
+    "outDir": "./lib",
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts"]

--- a/mf1/packages/parser/tsconfig.build.json
+++ b/mf1/packages/parser/tsconfig.build.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
-    "module": "CommonJS",
-    "outDir": "lib"
+    "outDir": "./lib",
+    "rootDir": "./src"
   },
   "include": ["src/*"],
   "exclude": ["**/*.test.ts"]

--- a/mf1/packages/react/package.json
+++ b/mf1/packages/react/package.json
@@ -20,6 +20,7 @@
   ],
   "license": "MIT",
   "homepage": "http://messageformat.github.io/messageformat/api/react/",
+  "type": "module",
   "main": "lib/index.js",
   "exports": {
     ".": "./lib/index.js",

--- a/mf1/packages/react/src/index.ts
+++ b/mf1/packages/react/src/index.ts
@@ -21,11 +21,15 @@
  * } from '@messageformat/react'
  * ```
  */
-export { getMessage, getMessageGetter } from './get-message';
-export { Message, MessageProps } from './message';
-export { MessageContext, MessageObject, MessageValue } from './message-context';
-export { MessageError } from './message-error';
-export { MessageProvider, MessageProviderProps } from './message-provider';
-export { useLocales } from './use-locales';
-export { useMessage } from './use-message';
-export { useMessageGetter } from './use-message-getter';
+export { getMessage, getMessageGetter } from './get-message.js';
+export { Message, MessageProps } from './message.js';
+export {
+  MessageContext,
+  MessageObject,
+  MessageValue
+} from './message-context.js';
+export { MessageError } from './message-error.js';
+export { MessageProvider, MessageProviderProps } from './message-provider.js';
+export { useLocales } from './use-locales.js';
+export { useMessage } from './use-message.js';
+export { useMessageGetter } from './use-message-getter.js';

--- a/mf1/packages/react/src/message-context.ts
+++ b/mf1/packages/react/src/message-context.ts
@@ -2,7 +2,7 @@
 // @ts-ignore - https://github.com/microsoft/rushstack/issues/1050
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Context, createContext } from 'react';
-import { ErrorCode } from './message-error';
+import { ErrorCode } from './message-error.js';
 
 /** @internal */
 export type MessageValue =

--- a/mf1/packages/react/src/message-provider.ts
+++ b/mf1/packages/react/src/message-provider.ts
@@ -1,6 +1,10 @@
 import { ReactNode, createElement, useContext, useMemo } from 'react';
-import { MessageContext, MessageObject, defaultValue } from './message-context';
-import { ErrorCode, MessageError, errorMessages } from './message-error';
+import {
+  MessageContext,
+  MessageObject,
+  defaultValue
+} from './message-context.js';
+import { ErrorCode, MessageError, errorMessages } from './message-error.js';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - https://github.com/microsoft/rushstack/issues/1050

--- a/mf1/packages/react/src/message.ts
+++ b/mf1/packages/react/src/message.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
-import { getMessage, getPath } from './get-message';
-import { MessageContext } from './message-context';
+import { getMessage, getPath } from './get-message.js';
+import { MessageContext } from './message-context.js';
 
 /** @public */
 export interface MessageProps {

--- a/mf1/packages/react/src/use-locales.ts
+++ b/mf1/packages/react/src/use-locales.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { MessageContext } from './message-context';
+import { MessageContext } from './message-context.js';
 
 /**
  * A custom React hook providing the current locales as an array of string identifiers, with earlier entries taking precedence over latter ones.

--- a/mf1/packages/react/src/use-message-getter.ts
+++ b/mf1/packages/react/src/use-message-getter.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
-import { MessageGetterOptions, getMessageGetter } from './get-message';
-import { MessageContext } from './message-context';
+import { MessageGetterOptions, getMessageGetter } from './get-message.js';
+import { MessageContext } from './message-context.js';
 
 /**
  * A custom [React hook] providing a message getter function, which may have a preset root id path, locale, and/or base parameters for message functions.

--- a/mf1/packages/react/src/use-message.ts
+++ b/mf1/packages/react/src/use-message.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
-import { getMessage } from './get-message';
-import { MessageContext } from './message-context';
+import { getMessage } from './get-message.js';
+import { MessageContext } from './message-context.js';
 
 /**
  * A custom React hook providing an entry from the messages object of the current or given locale.

--- a/mf1/packages/react/tsconfig.build.json
+++ b/mf1/packages/react/tsconfig.build.json
@@ -4,7 +4,8 @@
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "jsx": "react",
-    "outDir": "lib"
+    "outDir": "./lib",
+    "rootDir": "./src"
   },
   "include": ["src/*"],
   "exclude": ["**/*.test.tsx"]

--- a/mf1/packages/rollup-plugin/tsconfig.build.json
+++ b/mf1/packages/rollup-plugin/tsconfig.build.json
@@ -2,9 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
-    "module": "CommonJS",
-    "outDir": "lib/",
-    "removeComments": true
+    "outDir": "./lib",
+    "removeComments": true,
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/*"],
   "exclude": ["**/*.test.ts"]

--- a/mf1/packages/runtime/package.json
+++ b/mf1/packages/runtime/package.json
@@ -56,8 +56,8 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build:cjs": "tsc --project tsconfig.build.json --declaration --module CommonJS --outDir lib",
-    "build:esm": "tsc --project tsconfig.build.json --module ES6 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json --declaration --outDir lib",
+    "build:esm": "tsc --project tsconfig.build.json --module preserve --moduleResolution bundler --outDir esm",
     "build": "npm run build:cjs && npm run build:esm",
     "extract-api": "api-extractor run --local --verbose",
     "prepublishOnly": "npm run build"

--- a/mf1/packages/runtime/tsconfig.build.json
+++ b/mf1/packages/runtime/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES5"
+    "rootDir": "./src",
+    "target": "ES2017"
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts"]

--- a/mf1/tsconfig.base.json
+++ b/mf1/tsconfig.base.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "module": "ESNext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "resolveJsonModule": true,
+    //"resolveJsonModule": true,
     "strict": true,
     "target": "ES2023"
   }

--- a/mf2/fluent/tsconfig.build.json
+++ b/mf2/fluent/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "./lib",
+    "rootDir": "./src"
   },
   "include": ["src/*"],
   "exclude": ["**/*.test.*"]

--- a/mf2/icu-messageformat-1/tsconfig.build.json
+++ b/mf2/icu-messageformat-1/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "./lib",
+    "rootDir": "./src"
   },
   "include": ["src/*"],
   "exclude": ["**/*.test.*"]

--- a/mf2/messageformat/src/functions/number.ts
+++ b/mf2/messageformat/src/functions/number.ts
@@ -9,7 +9,7 @@ import { asPositiveInteger, asString } from './utils.ts';
 
 /**
  * The resolved value of a
- * {@link DraftFunctions.currency | :currency},
+ * {@link DefaultFunctions.currency | :currency},
  * {@link DefaultFunctions.integer | :integer},
  * {@link DefaultFunctions.number | :number},
  * {@link DefaultFunctions.offset | :offset},

--- a/mf2/messageformat/tsconfig.build.json
+++ b/mf2/messageformat/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.*", "**/test-*"]

--- a/mf2/resource/tsconfig.build.json
+++ b/mf2/resource/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "./lib",
+    "rootDir": "./src"
   },
   "include": ["src/*"],
   "exclude": ["**/*.test.*"]

--- a/mf2/tsconfig.json
+++ b/mf2/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "types": ["jest", "node"],
-    "baseUrl": ".",
     "paths": {
       "~/*": ["../*"],
       "@messageformat/fluent": ["fluent/src/index.ts"],

--- a/mf2/tsconfig.json
+++ b/mf2/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "types": ["jest", "node"],
+    // Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
+    // It's required here to satisy typedoc 0.28.19, which otherwise emits errors:
+    //   error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
+    "ignoreDeprecations": "6.0",
+    "baseUrl": ".",
+
     "paths": {
       "~/*": ["../*"],
       "@messageformat/fluent": ["fluent/src/index.ts"],
@@ -10,6 +15,7 @@
       ],
       "messageformat": ["messageformat/src/index.ts"],
       "messageformat/functions": ["messageformat/src/functions/index.ts"]
-    }
+    },
+    "types": ["jest", "node"]
   }
 }

--- a/mf2/xliff/tsconfig.build.json
+++ b/mf2/xliff/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib",
+    "outDir": "./lib",
+    "rootDir": "./src",
     "skipLibCheck": true
   },
   "include": ["src/*"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "tslib": "^2.8.1",
         "typedoc": "^0.28.9",
         "typedoc-plugin-redirect": "^1.2.0",
-        "typescript": "^5.7.2",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.8.0"
       },
       "engines": {
@@ -3748,6 +3748,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/universalify": {
@@ -10735,9 +10749,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "tslib": "^2.8.1",
     "typedoc": "^0.28.9",
     "typedoc-plugin-redirect": "^1.2.0",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.8.0"
   },
   "engines": {


### PR DESCRIPTION
Also apply required config changes & other fixes.

This changes the build target for `@messageformat/core` and `@messageformat/runtime` from ES5 to ES2017, but it looks like some ES2017-isms like `Object.entries()` were already in use.