### PR TITLE
Use `pgs:switch` & `pgs:case` instead of `mf:select` for MF2 Xliff representation

### DIFF
--- a/mf2/xliff/src/mf2-to-xliff.ts
+++ b/mf2/xliff/src/mf2-to-xliff.ts
@@ -14,8 +14,6 @@ import { toNmtoken } from './nmtoken.ts';
 let _id = 0;
 const nextId = () => String(++_id);
 
-const star = Symbol('*');
-
 // TODO: Support declarations
 export function mf2xliff(
   source: MessageFormatInfo,
@@ -51,16 +49,10 @@ export function mf2xliff(
   return { type: 'element', name: 'xliff', attributes, elements: [file] };
 }
 
-function msgId(
-  pre: 'f' | 'g' | 's' | 'u',
-  key: string[],
-  variant?: (string | typeof star)[]
-) {
+function msgId(pre: 'f' | 'g' | 's' | 'u', key: string[], variant?: string[]) {
   const id = `${pre}:${key.map(toNmtoken).join('.')}`;
   return variant?.length
-    ? `${id}:${variant
-        .map(v => (typeof v === 'string' ? toNmtoken(v) : '_other'))
-        .join('.')}`
+    ? `${id}:${variant.map(v => toNmtoken(v.replace('*:', ''))).join('.')}`
     : id;
 }
 
@@ -156,16 +148,22 @@ function resolveSelect(
     };
   }
 
-  const select: { id: string; keys: (string | typeof star)[] }[] =
-    srcSel.selectors.map(sel => ({ id: sel.name, keys: [] }));
+  const select: { id: string; keys: string[] }[] = srcSel.selectors.map(
+    sel => ({ id: sel.name, keys: [] })
+  );
   const segments: X.Segment[] = [];
 
   if (!trgSel) {
     // If there's only a source, we use its cases directly
     for (const v of srcSel.variants) {
       const segment = resolvePattern(v.value, undefined, rdElements);
-      const vk = v.keys.map(k => (k.type === '*' ? star : k.value));
-      segment.attributes = { id: msgId('s', key, vk) };
+      const vk = v.keys.map(k =>
+        k.type === '*' ? `*:${k.value ?? 'other'}` : k.value
+      );
+      segment.attributes = {
+        id: msgId('s', key, vk),
+        'pgs:case': vk.join(' ')
+      };
       segments.push(segment);
     }
   } else {
@@ -186,19 +184,23 @@ function resolveSelect(
     // Collect all of the key values for each case, in the right order
     const addSorted = (i: number, key: MF.Literal | MF.CatchallKey) => {
       const { keys } = select[i];
-      const sk = key.type === '*' ? star : key.value;
+      const isDefault = key.type === '*';
+      const sk = isDefault ? `*:${key.value ?? 'other'}` : key.value;
       if (keys.includes(sk)) return;
-      if (sk === star) {
+      if (isDefault) {
         keys.push(sk);
       } else if (Number.isFinite(Number(sk))) {
         let pos = 0;
-        while (keys[pos] !== star && Number.isFinite(Number(keys[pos]))) {
+        while (
+          !keys[pos].startsWith('*:') &&
+          Number.isFinite(Number(keys[pos]))
+        ) {
           pos += 1;
         }
         keys.splice(pos, 0, sk);
       } else {
         let pos = keys.length;
-        while (keys[pos - 1] === star) pos -= 1;
+        while (keys[pos - 1]?.startsWith('*:')) pos -= 1;
         keys.splice(pos, 0, sk);
       }
     };
@@ -227,15 +229,38 @@ function resolveSelect(
         throw new Error(`Case ${sk} not found‽ src:${srcCase} trg:${trgCase}`);
       }
       const segment = resolvePattern(srcCase.value, trgCase.value, rdElements);
-      segment.attributes = { id: msgId('s', key, sk) };
+      segment.attributes = {
+        id: msgId('s', key, sk),
+        'pgs:case': sk.join(' ')
+      };
       segments.push(segment);
     }
   }
 
   const unit = buildUnit(key, rdElements, segments);
   unit.attributes.canResegment = 'no';
-  unit.attributes['mf:select'] = select.map(s => s.id).join(' ');
+  unit.attributes['pgs:switch'] = select
+    .map(s => pgsSwitchValue(rdElements, s.id))
+    .join(' ');
   return unit;
+}
+
+function pgsSwitchValue(rdElements: X.ResourceItem[], id: string): string {
+  let kind = 'select';
+  const decl = rdElements.find(el => el.attributes.id === id);
+  const src = decl?.elements.find(el => el.name === 'res:source');
+  const func = (src?.elements as X.MessageFunction[])?.find(
+    el => el.name === 'mf:function'
+  );
+  if (func) {
+    const fnName = func.attributes.name;
+    if (fnName === 'number' || fnName === 'integer') {
+      const selOpt = func.elements?.find(el => el.attributes.name === 'select');
+      const selType = selOpt?.elements[0].elements?.[0] as X.Text | undefined;
+      kind = selType?.text === 'ordinal' ? 'ordinal' : 'plural';
+    }
+  }
+  return `${kind}:${id}`;
 }
 
 function resolveDeclarations(
@@ -348,12 +373,10 @@ function addRef(
   return { id, elements };
 }
 
-function everyKey(
-  select: { keys: (string | typeof star)[] }[]
-): Iterable<(string | typeof star)[]> {
+function everyKey(select: { keys: string[] }[]): Iterable<string[]> {
   let ptr: number[] | null = null;
   const max = select.map(s => s.keys.length - 1);
-  function next(): IteratorResult<(string | typeof star)[]> {
+  function next(): IteratorResult<string[]> {
     if (!ptr) {
       ptr = new Array<number>(select.length).fill(0);
     } else {

--- a/mf2/xliff/src/xliff-spec.ts
+++ b/mf2/xliff/src/xliff-spec.ts
@@ -357,7 +357,6 @@ export interface Unit<
     type?: string;
     'fs:fs'?: FormatStyle;
     'fs:subFs'?: string;
-    'mf:select'?: string;
 
     /**
      * Indicates the variable(s) used to select the message variant,

--- a/mf2/xliff/src/xliff-to-mf2.ts
+++ b/mf2/xliff/src/xliff-to-mf2.ts
@@ -20,7 +20,7 @@ export function* xliff2mf(
   const { srcLang, trgLang } = xliff.attributes;
   for (const file of xliff.elements) {
     if (file.name === 'file') {
-      const id = parseId('f', file.attributes.id).key.join('.');
+      const id = parseKeyFromId('file', file.attributes.id).join('.');
       const fileInfo = { id, srcLang, trgLang };
       for (const el of file.elements) {
         yield* resolveEntry(fileInfo, el);
@@ -40,11 +40,11 @@ function* resolveEntry(
         break;
       }
       case 'unit': {
-        const { key } = parseId('u', entry.attributes.id);
+        const key = parseKeyFromId('unit', entry.attributes.id);
         const rd = entry.elements.find(el => el.name === 'res:resourceData') as
           | X.ResourceData
           | undefined;
-        const { source, target } = entry.attributes['mf:select']
+        const { source, target } = entry.attributes['pgs:switch']
           ? resolveSelectMessage(rd, entry)
           : resolvePatternMessage(rd, entry);
         yield { file, key, source, target };
@@ -54,36 +54,30 @@ function* resolveEntry(
   }
 }
 
-function parseId(
-  pre: 's',
+function parseKeyFromId(
+  name: 'file' | 'group' | 'unit',
   id: string | undefined
-): { key: string[]; variant: MF.Variant['keys'] };
-function parseId(
-  pre: 'f' | 'g' | 'u',
-  id: string | undefined
-): { key: string[] };
-function parseId(
-  pre: 'f' | 'g' | 's' | 'u',
-  id: string | undefined
-): { key: string[]; variant?: MF.Variant['keys'] } {
+): string[] {
+  const pre = name[0] as 'f' | 'g' | 'u';
   const match = id?.match(/(?:_[_:]|[^:])+/g);
   if (match && match.length >= 2 && match[0] === pre) {
     const keyMatch = match[1].match(/(?:_[_.]|[^.])+/g);
-    const variantMatch = match[2]?.match(/(?:_[_.]|[^.])+/g);
-    if (keyMatch && (pre !== 's' || variantMatch)) {
-      return {
-        key: keyMatch.map(fromNmtoken),
-        variant: variantMatch?.map(v =>
-          v === '_other'
-            ? { type: '*' }
-            : { type: 'literal', quoted: false, value: fromNmtoken(v) }
-        )
-      };
+    if (keyMatch) return keyMatch.map(fromNmtoken);
+  }
+  const pe = prettyElement(name, id);
+  throw new Error(`Invalid id attribute for ${pe}`);
+}
+
+function parseVariantKeysFromPgsCase(
+  id: string | undefined
+): MF.Variant['keys'] {
+  const keys: MF.Variant['keys'] = [];
+  if (id) {
+    for (const [, isDefault, value] of id.matchAll(/(\*:)?(\S+)/g)) {
+      keys.push({ type: isDefault ? '*' : 'literal', value });
     }
   }
-  const el = { f: 'file', g: 'group', s: 'segment', u: 'unit' }[pre];
-  const pe = prettyElement(el, id);
-  throw new Error(`Invalid id attribute for ${pe}`);
+  return keys;
 }
 
 const prettyElement = (name: string, id: string | undefined) =>
@@ -111,7 +105,7 @@ function resolveSelectMessage(
   };
   for (const el of elements!) {
     if (el.name === 'segment') {
-      const keys = parseId('s', el.attributes?.id).variant;
+      const keys = parseVariantKeysFromPgsCase(el.attributes?.['pgs:case']);
       const pattern = resolvePattern(rd, el);
       source.variants.push({ keys, value: pattern.source });
       if (pattern.target) {
@@ -126,22 +120,25 @@ function resolveSelectMessage(
   const hasTarget = !!target.variants.length;
   const srcSelectors: boolean[] = [];
   const tgtSelectors: boolean[] = [];
-  for (const ref of attributes['mf:select']!.trim().split(/\s+/)) {
+  for (const ref of attributes['pgs:switch']!.matchAll(
+    /(gender|plural|ordinal|select):(\S+)/g
+  )) {
+    const name = ref[2];
     const ri = rd.elements.find(
       ri =>
         ri.name === 'res:resourceItem' &&
-        ri.attributes?.id === ref &&
+        ri.attributes?.id === name &&
         ri.attributes['mf:declaration']
     ) as X.ResourceItem | undefined;
-    if (!ri) throw new Error(`Unresolved MessageFormat reference: ${ref}`);
+    if (!ri) throw new Error(`Unresolved MessageFormat reference: ${ref[0]}`);
     let srcSel = false;
     let tgtSel = false;
     for (const el of ri.elements) {
       if (el.name === 'res:source') {
-        source.selectors.push({ type: 'variable', name: ref });
+        source.selectors.push({ type: 'variable', name });
         srcSel = true;
       } else if (hasTarget && el.name === 'res:target') {
-        target.selectors.push({ type: 'variable', name: ref });
+        target.selectors.push({ type: 'variable', name });
         tgtSel = true;
       }
     }

--- a/mf2/xliff/src/xliff.test.ts
+++ b/mf2/xliff/src/xliff.test.ts
@@ -18,6 +18,16 @@ test('source only', () => {
       parseMessage(
         '.input {$selector :string} .match $selector a {{A}} * {{B}}'
       )
+    ],
+    [
+      'plural',
+      parseMessage('.input {$n :integer} .match $n one {{A}} * {{B}}')
+    ],
+    [
+      'ordinal',
+      parseMessage(
+        '.input {$n :number select=ordinal} .match $n 1 {{First!}} * {{Not first}}'
+      )
     ]
   ]);
   const xliff = stringify(mf2xliff({ data, id: 'res', locale: 'en' }));
@@ -56,7 +66,7 @@ test('source only', () => {
             <source xml:space="preserve">This is the <ph id="4" mf:ref="ph:3"/></source>
           </segment>
         </unit>
-        <unit id="u:select" name="select" canResegment="no" mf:select="selector">
+        <unit id="u:select" name="select" canResegment="no" pgs:switch="select:selector">
           <res:resourceData>
             <res:resourceItem id="selector" mf:declaration="input">
               <res:source>
@@ -65,11 +75,47 @@ test('source only', () => {
               </res:source>
             </res:resourceItem>
           </res:resourceData>
-          <segment id="s:select:a">
+          <segment id="s:select:a" pgs:case="a">
             <source>A</source>
           </segment>
-          <segment id="s:select:_other">
+          <segment id="s:select:other" pgs:case="*:other">
             <source>B</source>
+          </segment>
+        </unit>
+        <unit id="u:plural" name="plural" canResegment="no" pgs:switch="plural:n">
+          <res:resourceData>
+            <res:resourceItem id="n" mf:declaration="input">
+              <res:source>
+                <mf:variable name="n"/>
+                <mf:function name="integer"/>
+              </res:source>
+            </res:resourceItem>
+          </res:resourceData>
+          <segment id="s:plural:one" pgs:case="one">
+            <source>A</source>
+          </segment>
+          <segment id="s:plural:other" pgs:case="*:other">
+            <source>B</source>
+          </segment>
+        </unit>
+        <unit id="u:ordinal" name="ordinal" canResegment="no" pgs:switch="ordinal:n">
+          <res:resourceData>
+            <res:resourceItem id="n" mf:declaration="input">
+              <res:source>
+                <mf:variable name="n"/>
+                <mf:function name="number">
+                  <mf:option name="select">
+                    <mf:literal>ordinal</mf:literal>
+                  </mf:option>
+                </mf:function>
+              </res:source>
+            </res:resourceItem>
+          </res:resourceData>
+          <segment id="s:ordinal:1" pgs:case="1">
+            <source>First!</source>
+          </segment>
+          <segment id="s:ordinal:other" pgs:case="*:other">
+            <source>Not first</source>
           </segment>
         </unit>
       </file>
@@ -85,21 +131,125 @@ test('source only', () => {
       } else {
         expect(file).toBe(file_);
       }
-      return [
-        key,
-        stringifyMessage(source),
-        target && stringifyMessage(target)
-      ];
+      expect(target).toBeUndefined();
+      return [key, source, stringifyMessage(source)];
     }
   );
   expect(res).toEqual([
-    [['msg'], 'Message', undefined],
-    [['var'], 'Foo {$num}', undefined],
-    [['ref'], 'This is the {msg :message @attr}', undefined],
+    [
+      ['msg'],
+      { type: 'message', declarations: [], pattern: ['Message'] },
+      'Message'
+    ],
+    [
+      ['var'],
+      {
+        type: 'message',
+        declarations: [],
+        pattern: [
+          'Foo ',
+          {
+            type: 'expression',
+            arg: { type: 'variable', name: 'num' },
+            attributes: {}
+          }
+        ]
+      },
+      'Foo {$num}'
+    ],
+    [
+      ['ref'],
+      {
+        type: 'message',
+        declarations: [],
+        pattern: [
+          'This is the ',
+          {
+            type: 'expression',
+            arg: { type: 'literal', value: 'msg' },
+            attributes: { attr: true },
+            functionRef: { type: 'function', name: 'message' }
+          }
+        ]
+      },
+      'This is the {msg :message @attr}'
+    ],
     [
       ['select'],
-      '.input {$selector :string}\n.match $selector\na {{A}}\n* {{B}}',
-      undefined
+      {
+        type: 'select',
+        declarations: [
+          {
+            type: 'input',
+            name: 'selector',
+            value: {
+              type: 'expression',
+              arg: { type: 'variable', name: 'selector' },
+              attributes: {},
+              functionRef: { type: 'function', name: 'string' }
+            }
+          }
+        ],
+        selectors: [{ name: 'selector', type: 'variable' }],
+        variants: [
+          { keys: [{ type: 'literal', value: 'a' }], value: ['A'] },
+          { keys: [{ type: '*', value: 'other' }], value: ['B'] }
+        ]
+      },
+      '.input {$selector :string}\n.match $selector\na {{A}}\n* {{B}}'
+    ],
+
+    [
+      ['plural'],
+      {
+        type: 'select',
+        declarations: [
+          {
+            type: 'input',
+            name: 'n',
+            value: {
+              type: 'expression',
+              arg: { type: 'variable', name: 'n' },
+              attributes: {},
+              functionRef: { type: 'function', name: 'integer' }
+            }
+          }
+        ],
+        selectors: [{ type: 'variable', name: 'n' }],
+        variants: [
+          { keys: [{ type: 'literal', value: 'one' }], value: ['A'] },
+          { keys: [{ type: '*', value: 'other' }], value: ['B'] }
+        ]
+      },
+      '.input {$n :integer}\n.match $n\none {{A}}\n* {{B}}'
+    ],
+    [
+      ['ordinal'],
+      {
+        type: 'select',
+        declarations: [
+          {
+            type: 'input',
+            name: 'n',
+            value: {
+              type: 'expression',
+              arg: { type: 'variable', name: 'n' },
+              attributes: {},
+              functionRef: {
+                type: 'function',
+                name: 'number',
+                options: { select: { type: 'literal', value: 'ordinal' } }
+              }
+            }
+          }
+        ],
+        selectors: [{ type: 'variable', name: 'n' }],
+        variants: [
+          { keys: [{ type: 'literal', value: '1' }], value: ['First!'] },
+          { keys: [{ type: '*', value: 'other' }], value: ['Not first'] }
+        ]
+      },
+      '.input {$n :number select=ordinal}\n.match $n\n1 {{First!}}\n* {{Not first}}'
     ]
   ]);
 });
@@ -178,7 +328,7 @@ test('combine source & target', () => {
           </unit>
         </group>
         <group id="g:select" name="select">
-          <unit id="u:select" name="select" canResegment="no" mf:select="selector">
+          <unit id="u:select" name="select" canResegment="no" pgs:switch="select:selector">
             <res:resourceData>
               <res:resourceItem id="selector" mf:declaration="input">
                 <res:source>
@@ -191,11 +341,11 @@ test('combine source & target', () => {
                 </res:target>
               </res:resourceItem>
             </res:resourceData>
-            <segment id="s:select:a">
+            <segment id="s:select:a" pgs:case="a">
               <source>A</source>
               <target>Ä</target>
             </segment>
-            <segment id="s:select:_other">
+            <segment id="s:select:b" pgs:case="*:b">
               <source>B</source>
               <target>B</target>
             </segment>
@@ -251,7 +401,7 @@ test('selector mismatch between source & target languages', () => {
     <xliff version="2.0" srcLang="en" xmlns="urn:oasis:names:tc:xliff:document:2.0" xmlns:mf="http://www.unicode.org/ns/2021/messageformat/2.0/not-real-yet" trgLang="fi">
       <file id="f:res">
         <group id="g:select" name="select">
-          <unit id="u:select" name="select" canResegment="no" mf:select="gender case">
+          <unit id="u:select" name="select" canResegment="no" pgs:switch="select:gender select:case">
             <res:resourceData>
               <res:resourceItem id="gender" mf:declaration="input">
                 <res:source>
@@ -266,27 +416,27 @@ test('selector mismatch between source & target languages', () => {
                 </res:target>
               </res:resourceItem>
             </res:resourceData>
-            <segment id="s:select:masculine.allative">
+            <segment id="s:select:masculine.allative" pgs:case="masculine allative">
               <source>his house</source>
               <target>hänen talolle</target>
             </segment>
-            <segment id="s:select:masculine._other">
+            <segment id="s:select:masculine.nominative" pgs:case="masculine *:nominative">
               <source>his house</source>
               <target>hänen talo</target>
             </segment>
-            <segment id="s:select:feminine.allative">
+            <segment id="s:select:feminine.allative" pgs:case="feminine allative">
               <source>her house</source>
               <target>hänen talolle</target>
             </segment>
-            <segment id="s:select:feminine._other">
+            <segment id="s:select:feminine.nominative" pgs:case="feminine *:nominative">
               <source>her house</source>
               <target>hänen talo</target>
             </segment>
-            <segment id="s:select:_other.allative">
+            <segment id="s:select:other.allative" pgs:case="*:other allative">
               <source>their house</source>
               <target>hänen talolle</target>
             </segment>
-            <segment id="s:select:_other._other">
+            <segment id="s:select:other.nominative" pgs:case="*:other *:nominative">
               <source>their house</source>
               <target>hänen talo</target>
             </segment>
@@ -300,7 +450,8 @@ test('selector mismatch between source & target languages', () => {
     Array.from(xliff2mf(xliff)).map(({ key, source, target }) => [
       key,
       stringifyMessage(source),
-      target && stringifyMessage(target)
+      stringifyMessage(target!),
+      target
     ])
   ).toEqual([
     [
@@ -316,7 +467,40 @@ test('selector mismatch between source & target languages', () => {
         .input {$case :string}
         .match $case
         allative {{hänen talolle}}
-        * {{hänen talo}}`
+        * {{hänen talo}}`,
+      {
+        type: 'select',
+        declarations: [
+          {
+            type: 'input',
+            name: 'gender',
+            value: {
+              type: 'expression',
+              arg: { type: 'variable', name: 'gender' },
+              functionRef: { type: 'function', name: 'string' },
+              attributes: {}
+            }
+          },
+          {
+            type: 'input',
+            name: 'case',
+            value: {
+              type: 'expression',
+              arg: { type: 'variable', name: 'case' },
+              functionRef: { type: 'function', name: 'string' },
+              attributes: {}
+            }
+          }
+        ],
+        selectors: [{ type: 'variable', name: 'case' }],
+        variants: [
+          {
+            keys: [{ type: 'literal', value: 'allative' }],
+            value: ['hänen talolle']
+          },
+          { keys: [{ type: '*', value: 'nominative' }], value: ['hänen talo'] }
+        ]
+      }
     ]
   ]);
 });
@@ -337,7 +521,7 @@ describe('Parsing xml:space in parent elements', () => {
       Array.from(xliff2mf(xliff)).map(({ key, source, target }) => [
         key,
         stringifyMessage(source),
-        target && stringifyMessage(target)
+        target
       ])
     ).toEqual([[['key'], ' Message ', undefined]]);
   });
@@ -359,7 +543,7 @@ describe('Parsing xml:space in parent elements', () => {
       Array.from(xliff2mf(xliff)).map(({ key, source, target }) => [
         key,
         stringifyMessage(source),
-        target && stringifyMessage(target)
+        target
       ])
     ).toEqual([[['key'], ' Message ', undefined]]);
   });
@@ -387,7 +571,7 @@ describe('Parsing xml:space in parent elements', () => {
       Array.from(xliff2mf(xliff)).map(({ key, source, target }) => [
         key,
         stringifyMessage(source),
-        target && stringifyMessage(target)
+        target
       ])
     ).toEqual([[['key'], ' Message {msg :message} ', undefined]]);
   });
@@ -396,7 +580,7 @@ describe('Parsing xml:space in parent elements', () => {
     const xliff = source`
     <xliff version="2.0" srcLang="en" xmlns="urn:oasis:names:tc:xliff:document:2.0" xmlns:mf="http://www.unicode.org/ns/2021/messageformat/2.0/not-real-yet">
       <file id="f:res">
-        <unit id="u:key" canResegment="no" mf:select="sel" xml:space="preserve">
+        <unit id="u:key" canResegment="no" pgs:switch="select:sel" xml:space="preserve">
           <res:resourceData>
             <res:resourceItem id="sel" mf:declaration="input">
               <res:source>
@@ -405,10 +589,10 @@ describe('Parsing xml:space in parent elements', () => {
               </res:source>
             </res:resourceItem>
           </res:resourceData>
-          <segment id="s:select:a">
+          <segment id="s:select:a" pgs:case="a">
             <source> A </source>
           </segment>
-          <segment id="s:select:_other">
+          <segment id="s:select:other" pgs:case="*:other">
             <source> B </source>
           </segment>
         </unit>
@@ -418,7 +602,7 @@ describe('Parsing xml:space in parent elements', () => {
       Array.from(xliff2mf(xliff)).map(({ key, source, target }) => [
         key,
         stringifyMessage(source),
-        target && stringifyMessage(target)
+        target
       ])
     ).toEqual([
       [
@@ -460,7 +644,7 @@ test('variably available targets', () => {
             <target></target>
           </segment>
         </unit>
-        <unit id="u:five" canResegment="no" mf:select="x">
+        <unit id="u:five" canResegment="no" pgs:switch="plural:x">
           <res:resourceData>
             <res:resourceItem id="x" mf:declaration="input">
               <res:source>
@@ -473,14 +657,14 @@ test('variably available targets', () => {
               </res:target>
             </res:resourceItem>
           </res:resourceData>
-          <segment id="s:select:0">
+          <segment id="s:select:0" pgs:case="0">
             <source>A</source>
             <target>Ä</target>
           </segment>
-          <segment id="s:select:one">
+          <segment id="s:select:one" pgs:case="one">
             <source>B</source>
           </segment>
-          <segment id="s:select:_other">
+          <segment id="s:select:other" pgs:case="*:other">
             <source>C</source>
             <target>C</target>
           </segment>


### PR DESCRIPTION
Fixes #456

This adopts the attributes introduced in the [Plural, Gender, and Select Module](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-extended-v2.2-part2.html#plural_gender_select_module) that was added in Xliff 2.2 rather than the `<unit mf:select>` and `<segment id>` attributes.

The `pgs:case` values use a `*:` prefix for the default case, as in `*:other` or `*:nominative`. This is a deliberate difference from the Xliff spec's [recommendation](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-extended-v2.2-part2.html#pgs_case:~:text=should%20also%20match), to allow for the identifier of the default case to be retained.

CC @srl295, @catamorphism