### PR TITLE
Add runtime resource parser + Improve CST resource parser

### DIFF
--- a/mf2/resource/src/cst-parser.test.ts
+++ b/mf2/resource/src/cst-parser.test.ts
@@ -109,7 +109,7 @@ test('multi-line entry', () => {
           [{ type: 'content', value: 'bar', range: [15, 18] }],
           [{ type: 'content', value: '}', range: [21, 22] }]
         ],
-        value: '{\n    bar\n  }',
+        value: '{\nbar\n}',
         range: [9, 22]
       },
       range: [0, 23]
@@ -150,7 +150,7 @@ test('multi-line entry with CRLF terminators', () => {
           [{ type: 'content', value: 'bar', range: [17, 20] }],
           [{ type: 'content', value: '}', range: [24, 25] }]
         ],
-        value: '{\r\n    bar\r\n  }',
+        value: '{\nbar\n}',
         range: [10, 25]
       },
       range: [0, 27]
@@ -225,7 +225,7 @@ test('escaped contents', () => {
             { type: 'content', value: 'lines}' }
           ]
         ],
-        value: '{\\{msg\\|\\nlines}'
+        value: '{\\{msg\\|\nlines}'
       }
     }
   ]);

--- a/mf2/resource/src/cst-parser.test.ts
+++ b/mf2/resource/src/cst-parser.test.ts
@@ -252,9 +252,9 @@ describe('duplicate identifiers', () => {
       }
     ]);
     expect(calls).toEqual([
-      [(res[0] as CST.Entry).id.range, 'Duplicate identifier'],
-      [(res[1] as CST.Entry).id.range, 'Duplicate identifier'],
-      [(res[2] as CST.Entry).id.range, 'Duplicate identifier']
+      [(res[0] as CST.Entry).id.range, 'Message already defined'],
+      [(res[1] as CST.Entry).id.range, 'Message already defined'],
+      [(res[2] as CST.Entry).id.range, 'Message already defined']
     ]);
   });
 
@@ -328,8 +328,8 @@ describe('errors', () => {
       }
     ]);
     expect(calls).toEqual([
-      [[0, 1], 'Invalid identifier character'],
-      [[8, 9], 'Invalid entry content character']
+      [[0, 1], 'Invalid entry identifier: Unsupported character'],
+      [[8, 9], 'Invalid entry value']
     ]);
   });
 
@@ -341,7 +341,7 @@ describe('errors', () => {
         id: { raw: [], value: [], range: [2, 3] }
       }
     ]);
-    expect(calls).toEqual([[[2, 3], 'Expected an identifier']]);
+    expect(calls).toEqual([[[2, 3], 'Invalid section identifier']]);
   });
 
   test('metadata without key', () => {
@@ -390,8 +390,8 @@ describe('errors', () => {
       }
     ]);
     expect(calls).toEqual([
-      [[2, 6], 'Unexpected content at line end'],
-      [[2, 3], 'Leading dot in identifier'],
+      [[2, 6], 'Invalid metadata: Unexpected content at line end'],
+      [[2, 3], 'Invalid entry identifier: Leading dot'],
       [[6, 7], 'Expected a = character here']
     ]);
   });
@@ -411,9 +411,9 @@ describe('errors', () => {
       }
     ]);
     expect(calls).toEqual([
-      [[1, 2], 'Leading dot in identifier'],
-      [[1, 3], 'Repeated dots in identifier'],
-      [[2, 3], 'Trailing dot in identifier']
+      [[1, 2], 'Invalid section identifier: Leading dot'],
+      [[1, 3], 'Invalid section identifier: Repeated dots'],
+      [[2, 3], 'Invalid section identifier: Trailing dot']
     ]);
   });
 
@@ -431,7 +431,9 @@ describe('errors', () => {
         }
       }
     ]);
-    expect(calls).toEqual([[[2, 3], 'Unexpected whitespace in identifier']]);
+    expect(calls).toEqual([
+      [[2, 3], 'Invalid section identifier: Unexpected whitespace']
+    ]);
   });
 
   test('character escapes', () => {
@@ -495,7 +497,7 @@ describe('errors', () => {
     ]);
     expect(calls).toEqual([
       [[2, 3], 'Expected a ] character here'],
-      [[4, 5], 'Unexpected whitespace in identifier'],
+      [[4, 5], 'Invalid entry identifier: Unexpected whitespace'],
       [[7, 8], 'Expected a = character here']
     ]);
   });
@@ -517,8 +519,8 @@ describe('errors', () => {
       { type: 'comment', content: 'd', range: [9, 11] }
     ]);
     expect(calls).toEqual([
-      [[2, 4], 'Content with unexpected indent'],
-      [[9, 11], 'Unexpected content at line end']
+      [[2, 4], 'Invalid indent'],
+      [[9, 11], 'Invalid section identifier: Unexpected content at line end']
     ]);
   });
 });

--- a/mf2/resource/src/cst-parser.test.ts
+++ b/mf2/resource/src/cst-parser.test.ts
@@ -70,6 +70,57 @@ test('frontmatter', () => {
   ]);
 });
 
+test('empty entries', () => {
+  const res = parseOk('foo = \nbar =\nbaz=');
+  expect(res).toEqual<TestResource>([
+    {
+      type: 'entry',
+      id: {
+        raw: [{ type: 'content', value: 'foo', range: [0, 3] }],
+        value: ['foo'],
+        range: [0, 3]
+      },
+      equal: 4,
+      value: {
+        raw: [],
+        value: '',
+        range: [5, 5]
+      },
+      range: [0, 7]
+    },
+    {
+      type: 'entry',
+      id: {
+        raw: [{ type: 'content', value: 'bar', range: [7, 10] }],
+        value: ['bar'],
+        range: [7, 10]
+      },
+      equal: 11,
+      value: {
+        raw: [],
+        value: '',
+        range: [12, 12]
+      },
+      range: [7, 13]
+    },
+    {
+      type: 'entry',
+      id: {
+        raw: [{ type: 'content', value: 'baz', range: [13, 16] }],
+        value: ['baz'],
+        range: [13, 16]
+      },
+      equal: 16,
+      value: {
+        raw: [],
+        value: '',
+        range: [17, 17]
+      },
+      range: [13, 17]
+    }
+  ]);
+});
+
 test('one-line entry', () => {
   const res = parseOk('foo = {bar}');
   expect(res).toEqual<TestResource>([
@@ -128,6 +179,44 @@ test('multi-line entry', () => {
         range: [28, 35]
       },
       range: [23, 35]
+    }
+  ]);
+});
+
+test('multi-line entry with empty lines', () => {
+  const res = parseOk('foo = \n\n  {\n\n    bar\n  }\n\nnext={value}');
+  expect(res).toMatchObject<TestResource>([
+    {
+      type: 'entry',
+      id: {
+        raw: [{ type: 'content', value: 'foo' }],
+        value: ['foo']
+      },
+      equal: 4,
+      value: {
+        raw: [
+          [],
+          [],
+          [{ type: 'content', value: '{' }],
+          [],
+          [{ type: 'content', value: 'bar' }],
+          [{ type: 'content', value: '}' }]
+        ],
+        value: '{\n\nbar\n}'
+      }
+    },
+    { type: 'empty-line' },
+    {
+      type: 'entry',
+      id: {
+        raw: [{ type: 'content', value: 'next' }],
+        value: ['next']
+      },
+      equal: 30,
+      value: {
+        raw: [[{ type: 'content', value: '{value}' }]],
+        value: '{value}'
+      }
     }
   ]);
 });

--- a/mf2/resource/src/cst-parser.test.ts
+++ b/mf2/resource/src/cst-parser.test.ts
@@ -29,21 +29,17 @@ function parseFail(source: string) {
 
 test('empty string', () => {
   const res = parseOk('');
-  expect(res).toMatchObject<TestResource>([
-    { type: 'empty-line', range: [0, 0] }
-  ]);
+  expect(res).toEqual<TestResource>([{ type: 'empty-line', range: [0, 0] }]);
 });
 
 test('single line terminator', () => {
   const res = parseOk('\r\n');
-  expect(res).toMatchObject<TestResource>([
-    { type: 'empty-line', range: [0, 2] }
-  ]);
+  expect(res).toEqual<TestResource>([{ type: 'empty-line', range: [0, 2] }]);
 });
 
 test('comments and empty lines', () => {
   const res = parseOk('\n\n#[foo\\] \n## bar\r\n  \t\n#');
-  expect(res).toMatchObject<TestResource>([
+  expect(res).toEqual<TestResource>([
     { type: 'empty-line', range: [0, 1] },
     { type: 'empty-line', range: [1, 2] },
     { type: 'comment', content: '[foo\\] ', range: [2, 11] },
@@ -53,9 +49,30 @@ test('comments and empty lines', () => {
   ]);
 });
 
+test('frontmatter', () => {
+  const res = parseOk('@locale en-ZZ\n---\n');
+  expect(res).toEqual<TestResource>([
+    {
+      type: 'metadata',
+      key: {
+        range: [1, 7],
+        raw: [{ range: [1, 7], type: 'content', value: 'locale' }],
+        value: 'locale'
+      },
+      range: [0, 14],
+      value: {
+        range: [8, 13],
+        raw: [[{ range: [8, 13], type: 'content', value: 'en-ZZ' }]],
+        value: 'en-ZZ'
+      }
+    },
+    { range: [14, 18], type: 'frontmatter' }
+  ]);
+});
+
 test('one-line entry', () => {
   const res = parseOk('foo = {bar}');
-  expect(res).toMatchObject<TestResource>([
+  expect(res).toEqual<TestResource>([
     {
       type: 'entry',
       id: {
@@ -76,7 +93,7 @@ test('one-line entry', () => {
 
 test('multi-line entry', () => {
   const res = parseOk('foo = \n  {\n    bar\n  }\nnext={value}');
-  expect(res).toMatchObject<TestResource>([
+  expect(res).toEqual<TestResource>([
     {
       type: 'entry',
       id: {
@@ -117,7 +134,7 @@ test('multi-line entry', () => {
 
 test('multi-line entry with CRLF terminators', () => {
   const res = parseOk('foo = \r\n  {\r\n    bar\r\n  }\r\n');
-  expect(res).toMatchObject<TestResource>([
+  expect(res).toEqual<TestResource>([
     {
       type: 'entry',
       id: {
@@ -133,7 +150,8 @@ test('multi-line entry with CRLF terminators', () => {
           [{ type: 'content', value: 'bar', range: [17, 20] }],
           [{ type: 'content', value: '}', range: [24, 25] }]
         ],
-        value: '{\r\n    bar\r\n  }'
+        value: '{\r\n    bar\r\n  }',
+        range: [10, 25]
       },
       range: [0, 27]
     }
@@ -142,7 +160,7 @@ test('multi-line entry with CRLF terminators', () => {
 
 test('section-head with trailing whitespace', () => {
   const res = parseOk('[ foo . bar ] \t\n');
-  expect(res).toMatchObject<TestResource>([
+  expect(res).toEqual<TestResource>([
     {
       type: 'section-head',
       id: {
@@ -233,7 +251,7 @@ describe('duplicate identifiers', () => {
         value: { raw: [[{ type: 'content', value: '3' }]] }
       }
     ]);
-    expect(calls).toMatchObject([
+    expect(calls).toEqual([
       [(res[0] as CST.Entry).id.range, 'Duplicate identifier'],
       [(res[1] as CST.Entry).id.range, 'Duplicate identifier'],
       [(res[2] as CST.Entry).id.range, 'Duplicate identifier']
@@ -282,7 +300,7 @@ describe('duplicate identifiers', () => {
       },
       { type: 'section-head', id: { value: ['a', 'b'] } }
     ]);
-    expect(calls).toMatchObject([
+    expect(calls).toEqual([
       [
         (res[0] as CST.Entry).id.range,
         'Shorter matching identifier must precede longer one'
@@ -309,7 +327,7 @@ describe('errors', () => {
         value: { raw: [[{ type: 'content', value: 'foo\u2028bar' }]] }
       }
     ]);
-    expect(calls).toMatchObject([
+    expect(calls).toEqual([
       [[0, 1], 'Invalid identifier character'],
       [[8, 9], 'Invalid entry content character']
     ]);
@@ -320,10 +338,62 @@ describe('errors', () => {
     expect(res).toMatchObject<TestResource>([
       {
         type: 'section-head',
-        id: { raw: [], value: [], range: [2, 2] }
+        id: { raw: [], value: [], range: [2, 3] }
       }
     ]);
-    expect(calls).toMatchObject([[[2, 3], 'Expected an identifier']]);
+    expect(calls).toEqual([[[2, 3], 'Expected an identifier']]);
+  });
+
+  test('metadata without key', () => {
+    const [res, calls] = parseFail('@ x');
+    expect(res).toEqual<TestResource>([
+      {
+        type: 'metadata',
+        key: { range: [1, 2], raw: [], value: '' },
+        value: {
+          raw: [[{ range: [2, 3], type: 'content', value: 'x' }]],
+          value: 'x',
+          range: [2, 3]
+        },
+        range: [0, 3]
+      }
+    ]);
+    expect(calls).toEqual([[[1, 2], 'Expected a metadata key']]);
+  });
+
+  test('metadata with no whitespace between key & value', () => {
+    const [res, calls] = parseFail('@x.foo');
+    expect(res).toEqual<TestResource>([
+      {
+        type: 'metadata',
+        key: {
+          raw: [{ range: [1, 2], type: 'content', value: 'x' }],
+          value: 'x',
+          range: [1, 2]
+        },
+        value: { range: [2, 2], raw: [], value: '' },
+        range: [0, 2]
+      },
+      {
+        type: 'entry',
+        id: {
+          range: [2, 6],
+          raw: [
+            { range: [2, 3], type: 'dot' },
+            { range: [3, 6], type: 'content', value: 'foo' }
+          ],
+          value: ['foo']
+        },
+        equal: -1,
+        value: { range: [6, 6], raw: [], value: '' },
+        range: [2, 6]
+      }
+    ]);
+    expect(calls).toEqual([
+      [[2, 6], 'Unexpected content at line end'],
+      [[2, 3], 'Leading dot in identifier'],
+      [[6, 7], 'Expected a = character here']
+    ]);
   });
 
   test('identifier dots', () => {
@@ -340,7 +410,7 @@ describe('errors', () => {
         }
       }
     ]);
-    expect(calls).toMatchObject([
+    expect(calls).toEqual([
       [[1, 2], 'Leading dot in identifier'],
       [[1, 3], 'Repeated dots in identifier'],
       [[2, 3], 'Trailing dot in identifier']
@@ -361,9 +431,7 @@ describe('errors', () => {
         }
       }
     ]);
-    expect(calls).toMatchObject([
-      [[2, 3], 'Unexpected whitespace in identifier']
-    ]);
+    expect(calls).toEqual([[[2, 3], 'Unexpected whitespace in identifier']]);
   });
 
   test('character escapes', () => {
@@ -391,7 +459,7 @@ describe('errors', () => {
         }
       }
     ]);
-    expect(calls).toMatchObject([
+    expect(calls).toEqual([
       [[0, 2], 'Unknown character escape'],
       [[4, 6], 'Unknown character escape'],
       [[7, 9], 'Unknown character escape'],
@@ -425,7 +493,7 @@ describe('errors', () => {
         value: { raw: [[{ type: 'content', value: '] d', range: [7, 10] }]] }
       }
     ]);
-    expect(calls).toMatchObject([
+    expect(calls).toEqual([
       [[2, 3], 'Expected a ] character here'],
       [[4, 5], 'Unexpected whitespace in identifier'],
       [[7, 8], 'Expected a = character here']
@@ -448,7 +516,7 @@ describe('errors', () => {
       },
       { type: 'comment', content: 'd', range: [9, 11] }
     ]);
-    expect(calls).toMatchObject([
+    expect(calls).toEqual([
       [[2, 4], 'Content with unexpected indent'],
       [[9, 11], 'Unexpected content at line end']
     ]);

--- a/mf2/resource/src/cst-parser.ts
+++ b/mf2/resource/src/cst-parser.ts
@@ -1,12 +1,21 @@
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CST {
-  export type Resource = Array<EmptyLine | Comment | SectionHead | Entry>;
+  export type Resource = Array<
+    EmptyLine | Comment | Frontmatter | Metadata | SectionHead | Entry
+  >;
 
   export type EmptyLine = { type: 'empty-line'; range: Range };
   export type Comment = {
     type: 'comment';
     /** Does not include the `#` or the line terminator. */
     content: string;
+    range: Range;
+  };
+  export type Frontmatter = { type: 'frontmatter'; range: Range };
+  export type Metadata = {
+    type: 'metadata';
+    key: IdPart;
+    value: Value;
     range: Range;
   };
   export type SectionHead = {
@@ -26,9 +35,14 @@ export namespace CST {
     range: Range;
   };
 
-  export type Id = { raw: IdPart[]; value: string[]; range: Range };
-  export type IdPart = Content | Escape | IdDot;
+  export type Id = { raw: IdElem[]; value: string[]; range: Range };
+  export type IdElem = Content | Escape | IdDot;
   export type IdDot = { type: 'dot'; range: Range };
+  export type IdPart = {
+    raw: (Content | Escape)[];
+    value: string;
+    range: Range;
+  };
 
   export type Value = { raw: ValuePart[][]; value: string; range: Range };
   export type ValuePart = Content | Escape;
@@ -99,6 +113,15 @@ export function parseCST(
           sectionId = sh.id.value;
         }
         break;
+      case '@':
+        res.push(parseMetadata());
+        break;
+      case '-':
+        if (source.startsWith('---', pos)) {
+          res.push(parseFrontmatter());
+          break;
+        }
+      // fallthrough
       default:
         res.push(parseEntry(sectionId));
         break;
@@ -133,12 +156,22 @@ function parseComment(): CST.Comment {
   return { type: 'comment', content, range: [start, pos] };
 }
 
+// frontmatter = "---" [ws]
+function parseFrontmatter(): CST.Frontmatter {
+  const type = 'frontmatter';
+  const start = pos;
+  pos += 3; // '---'
+  parseWhitespace();
+  parseLineEnd(type);
+  return { type, range: [start, pos] };
+}
+
 // section-head = "[" [ws] id [ws] "]" [ws]
 function parseSectionHead(): CST.SectionHead {
   const type = 'section-head';
   const start = pos;
   pos += 1; // '['
-  const id = parseId();
+  const id = parseId(type);
   const close = parseChar(']');
   parseWhitespace();
   parseLineEnd(type);
@@ -146,8 +179,40 @@ function parseSectionHead(): CST.SectionHead {
   return { type, id, close, range: [start, pos] };
 }
 
+// metadata = "@" id-part [ws value]
+function parseMetadata(): CST.Metadata {
+  const type = 'metadata';
+  const start = pos;
+  pos += 1; // '@'
+  const key = parseId(type);
+  const idEnd = pos;
+  parseWhitespace();
+  if (pos > idEnd) {
+    const value = parseValue();
+    return { type, key, value, range: [start, pos] };
+  } else {
+    parseLineEnd(type);
+    return {
+      type,
+      key,
+      value: { raw: [], value: '', range: [pos, pos] },
+      range: [start, pos]
+    };
+  }
+}
+
+// entry = id [ws] "=" [ws] value
+function parseEntry(sectionId: string[]): CST.Entry {
+  const type = 'entry';
+  const start = pos;
+  const id = parseId(type);
+  checkId(sectionId, id);
+  const equal = parseChar('=');
+  const value = parseValue();
+  return { type, id, equal, value, range: [start, pos] };
+}
+
 /**
- * entry = id [ws] "=" [ws] value
  * value = value-line *(newline ws value-line)
  * value-line = [(value-start / value-escape) *(content / value-escape)]
  * value-start = %x21-5B / %x5D-7E / %x00A0-2027 / %x202A-D7FF / %xE000-10FFFF
@@ -155,23 +220,16 @@ function parseSectionHead(): CST.SectionHead {
  */
 const contentRegExp =
   /[\t\x20-\x5B\x5D-\x7E\u{A0}-\u{2027}\u{202A}-\u{D7FF}\u{E000}-\u{10FFFF}]/u;
-function parseEntry(sectionId: string[]): CST.Entry {
-  const type = 'entry';
-  const start = pos;
-  const id = parseId();
-  checkId(sectionId, id);
-  const equal = parseChar('=');
-
-  let valueStart = -1;
-  let valueEnd = pos;
+function parseValue(): CST.Value {
+  let start = -1;
+  let end = pos;
   let range: CST.Range | null = null;
   const addContent = (line: CST.ValuePart[]) => {
     if (range) {
-      const [start, end] = range;
-      const value = source.substring(start, end);
+      const value = source.substring(range[0], range[1]);
       line.push({ type: 'content', value, range });
-      if (valueStart < 0) valueStart = start;
-      valueEnd = end;
+      if (start < 0) start = range[0];
+      end = range[1];
       range = null;
     }
   };
@@ -192,8 +250,8 @@ function parseEntry(sectionId: string[]): CST.Entry {
           addContent(line);
           const esc = parseEscape('value');
           line.push(esc);
-          if (valueStart < 0) valueStart = esc.range[0];
-          valueEnd = esc.range[1];
+          if (start < 0) start = esc.range[0];
+          end = esc.range[1];
           break;
         }
         default: {
@@ -209,31 +267,37 @@ function parseEntry(sectionId: string[]): CST.Entry {
     }
     addContent(line);
     raw.push(line);
-    parseLineEnd(type);
+    parseLineEnd();
   }
 
-  if (valueStart < 0) valueStart = valueEnd;
-  const value: CST.Value = {
+  if (start < 0) start = end;
+  return {
     raw,
-    value: source.substring(valueStart, valueEnd),
-    range: [valueStart, valueEnd]
+    value: source.substring(start, end),
+    range: [start, end]
   };
-  return { type, id, equal, value, range: [start, pos] };
 }
 
 /**
- * id = id-part *([ws] "." [ws] id-part)
- * id-part = 1*(id-char / id-escape)
- * id-char = ALPHA / DIGIT / "-" / "_"
+ * id = id-start *([ws] "." [ws] id-part)
+ * id-start = (["-"] ["-"] id-char [id-part]) / ("-" ["-"])
+ * id-part = 1*(id-char / "-")
+ * id-char = id-safe / id-escape
+ * id-safe = ALPHA / DIGIT / "_"
  *         / %x00A1-1FFF / %x200C-200D / %x2030-205E / %x2070-2FEF
  *         / %x3001-D7FF / %xF900-FDCF / %xFDF0-FFFD / %x10000-EFFFF
  */
 const idCharRegExp =
   /[-a-zA-Z0-9_\u{A1}-\u{1FFF}\u{200C}-\u{200D}\u{2030}-\u{205E}\u{2070}-\u{2FEF}\u{3001}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFFD}\u{10000}-\u{EFFFF}]/u;
-function parseId(): CST.Id {
+function parseId(type: 'entry' | 'section-head'): CST.Id;
+function parseId(type: 'metadata'): CST.IdPart;
+function parseId(
+  type: 'entry' | 'section-head' | 'metadata'
+): CST.Id | CST.IdPart {
+  const asIdPart = type === 'metadata';
   let start = pos;
   let end = pos;
-  const raw: CST.IdPart[] = [];
+  const raw: CST.IdElem[] = [];
   const value: string[] = [];
 
   let curr = '';
@@ -268,6 +332,7 @@ function parseId(): CST.Id {
         break;
       }
       case '.': {
+        if (asIdPart) break loop;
         addContent(true);
         const range: CST.Range = [pos, pos + 1];
         const prev = raw.at(-1);
@@ -283,6 +348,7 @@ function parseId(): CST.Id {
       }
       case '\t':
       case ' ':
+        if (asIdPart) break loop;
         addContent(true);
         parseWhitespace();
         if (raw.length === 0) start = pos; // trim leading spaces
@@ -309,13 +375,28 @@ function parseId(): CST.Id {
   }
   addContent(true);
 
-  const last = raw.at(-1);
-  if (!last) {
-    onError([start, Math.max(start + 1, end)], 'Expected an identifier');
-  } else if (last.type === 'dot') {
-    onError(last.range, 'Trailing dot in identifier');
+  const first = raw[0];
+  range = [start, Math.max(start + 1, end)];
+
+  if (asIdPart) {
+    if (!first) onError(range, 'Expected a metadata key');
+    return {
+      raw: raw as (CST.Content | CST.Escape)[],
+      value: value[0] ?? '',
+      range
+    };
   }
-  return { raw, value, range: [start, Math.max(start, end)] };
+
+  if (!first) {
+    onError(range, 'Expected an identifier');
+  } else if (first.type === 'content' && first.value.startsWith('---')) {
+    onError(first.range, 'Identifier must not start with ---');
+  }
+
+  const last = raw.at(-1);
+  if (last?.type === 'dot') onError(last.range, 'Trailing dot in identifier');
+
+  return { raw, value, range };
 }
 
 function checkId(sectionId: string[], { value, range }: CST.Id) {
@@ -431,7 +512,7 @@ function parseChar(char: string) {
 }
 
 // newline = CRLF / LF
-function parseLineEnd(type: string) {
+function parseLineEnd(type?: string) {
   let count = 0;
   let ch = source[pos];
   if (ch === '\r') {

--- a/mf2/resource/src/cst-parser.ts
+++ b/mf2/resource/src/cst-parser.ts
@@ -162,7 +162,7 @@ function parseFrontmatter(): CST.Frontmatter {
   const start = pos;
   pos += 3; // '---'
   parseWhitespace();
-  parseLineEnd(type);
+  parseLineEnd('frontmatter separator');
   return { type, range: [start, pos] };
 }
 
@@ -171,7 +171,7 @@ function parseSectionHead(): CST.SectionHead {
   const type = 'section-head';
   const start = pos;
   pos += 1; // '['
-  const id = parseId(type);
+  const id = parseId('section');
   const close = parseChar(']');
   parseWhitespace();
   parseLineEnd(type);
@@ -257,7 +257,7 @@ function parseValue(): CST.Value {
         default: {
           const next = pos + 1;
           if (!contentRegExp.test(ch)) {
-            onError([pos, next], 'Invalid entry content character');
+            onError([pos, next], 'Invalid entry value');
           }
           if (range) range[1] = next;
           else range = [pos, next];
@@ -267,7 +267,7 @@ function parseValue(): CST.Value {
     }
     addContent(line);
     raw.push(line);
-    parseLineEnd();
+    parseLineEnd('entry');
   }
 
   if (start < 0) start = end;
@@ -289,12 +289,14 @@ function parseValue(): CST.Value {
  */
 const idCharRegExp =
   /[-a-zA-Z0-9_\u{A1}-\u{1FFF}\u{200C}-\u{200D}\u{2030}-\u{205E}\u{2070}-\u{2FEF}\u{3001}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFFD}\u{10000}-\u{EFFFF}]/u;
-function parseId(type: 'entry' | 'section-head'): CST.Id;
-function parseId(type: 'metadata'): CST.IdPart;
+function parseId(context: 'entry' | 'section'): CST.Id;
+function parseId(context: 'metadata'): CST.IdPart;
 function parseId(
-  type: 'entry' | 'section-head' | 'metadata'
+  context: 'entry' | 'section' | 'metadata'
 ): CST.Id | CST.IdPart {
-  const asIdPart = type === 'metadata';
+  const onIdError = (range: CST.Range, msg: string) =>
+    onError(range, `Invalid ${context} identifier: ${msg}`);
+  const asIdPart = context === 'metadata';
   let start = pos;
   let end = pos;
   const raw: CST.IdElem[] = [];
@@ -337,9 +339,9 @@ function parseId(
         const range: CST.Range = [pos, pos + 1];
         const prev = raw.at(-1);
         if (!prev) {
-          onError(range, 'Leading dot in identifier');
+          onIdError(range, 'Leading dot');
         } else if (prev.type === 'dot') {
-          onError([prev.range[0], pos + 1], 'Repeated dots in identifier');
+          onIdError([prev.range[0], pos + 1], 'Repeated dots');
         }
         raw.push({ type: 'dot', range });
         pos += 1;
@@ -361,14 +363,11 @@ function parseId(
           range = [pos, end];
           const prev = raw.at(-1);
           if (prev?.type === 'content') {
-            onError(
-              [prev.range[1], pos],
-              'Unexpected whitespace in identifier'
-            );
+            onIdError([prev.range[1], pos], 'Unexpected whitespace');
           }
         }
         if (!idCharRegExp.test(ch)) {
-          onError([pos, end], 'Invalid identifier character');
+          onIdError([pos, end], 'Unsupported character');
         }
         pos = end;
     }
@@ -388,13 +387,15 @@ function parseId(
   }
 
   if (!first) {
-    onError(range, 'Expected an identifier');
+    onError(range, `Invalid ${context} identifier`);
   } else if (first.type === 'content' && first.value.startsWith('---')) {
-    onError(first.range, 'Identifier must not start with ---');
+    onError(first.range, 'Invalid frontmatter separator');
   }
 
   const last = raw.at(-1);
-  if (last?.type === 'dot') onError(last.range, 'Trailing dot in identifier');
+  if (last?.type === 'dot') {
+    onError(last.range, `Invalid ${context} identifier: Trailing dot`);
+  }
 
   return { raw, value, range };
 }
@@ -408,12 +409,12 @@ function checkId(sectionId: string[], { value, range }: CST.Id) {
     for (let i = 0; i < minLen; ++i) {
       if (path[i] !== prev.path[i]) continue paths;
     }
-    const msg =
-      path.length < prevLen
-        ? 'Shorter matching identifier must precede longer one'
-        : path.length === prevLen
-          ? 'Duplicate identifier'
-          : '';
+    let msg = '';
+    if (path.length < prevLen) {
+      msg = 'Shorter matching identifier must precede longer one';
+    } else if (path.length === prevLen) {
+      msg = 'Message already defined';
+    }
     if (msg) {
       if (!prev.error) {
         onError(prev.range, msg);
@@ -512,7 +513,7 @@ function parseChar(char: string) {
 }
 
 // newline = CRLF / LF
-function parseLineEnd(type?: string) {
+function parseLineEnd(type: string) {
   let count = 0;
   let ch = source[pos];
   if (ch === '\r') {
@@ -524,10 +525,20 @@ function parseLineEnd(type?: string) {
   } else if (pos < source.length) {
     let end = source.indexOf('\n', pos);
     if (end === -1) end = source.length;
-    const msg =
-      type === 'empty-line'
-        ? 'Content with unexpected indent'
-        : 'Unexpected content at line end';
+    let msg;
+    switch (type) {
+      case 'empty-line':
+        msg = 'Invalid indent';
+        break;
+      case 'frontmatter':
+        msg = 'Invalid frontmatter separator';
+        break;
+      case 'section-head':
+        msg = 'Invalid section identifier: Unexpected content at line end';
+        break;
+      default:
+        msg = `Invalid ${type}: Unexpected content at line end`;
+    }
     onError([pos, end], msg);
   }
 }

--- a/mf2/resource/src/cst-parser.ts
+++ b/mf2/resource/src/cst-parser.ts
@@ -213,7 +213,7 @@ function parseEntry(sectionId: string[]): CST.Entry {
 }
 
 /**
- * value = value-line *(newline ws value-line)
+ * value = value-line *(1*newline ws value-line)
  * value-line = [(value-start / value-escape) *(content / value-escape)]
  * value-start = %x21-5B / %x5D-7E / %x00A0-2027 / %x202A-D7FF / %xE000-10FFFF
  * content = SP / HTAB / value-start
@@ -238,7 +238,14 @@ function parseValue(): CST.Value {
   while (pos < source.length) {
     const ls = pos;
     parseWhitespace();
-    if (pos === ls && raw.length > 0) break;
+    if (
+      pos === ls &&
+      raw.length > 0 &&
+      source[pos] !== '\n' &&
+      !source.startsWith('\r\n', pos)
+    ) {
+      break;
+    }
     const line: CST.ValuePart[] = [];
     line: while (pos < source.length) {
       const ch = source[pos];
@@ -267,6 +274,15 @@ function parseValue(): CST.Value {
     }
     addContent(line);
     raw.push(line);
+    parseLineEnd('entry');
+  }
+
+  // Rewind to exclude trailing empty lines from the value
+  const rl0 = raw.length;
+  while (raw.at(-1)?.length === 0) raw.pop();
+  if (raw.length < rl0) {
+    pos = end;
+    parseWhitespace();
     parseLineEnd('entry');
   }
 

--- a/mf2/resource/src/cst-parser.ts
+++ b/mf2/resource/src/cst-parser.ts
@@ -270,12 +270,17 @@ function parseValue(): CST.Value {
     parseLineEnd('entry');
   }
 
+  const value = [];
+  for (const line of raw) {
+    let valueLine = '';
+    for (const vp of line) {
+      valueLine +=
+        vp.type === 'content' ? vp.value : parseEscapeValue('value', vp.raw);
+    }
+    if (valueLine || value.length) value.push(valueLine);
+  }
   if (start < 0) start = end;
-  return {
-    raw,
-    value: source.substring(start, end),
-    range: [start, end]
-  };
+  return { raw, value: value.join('\n'), range: [start, end] };
 }
 
 /**

--- a/mf2/resource/src/index.ts
+++ b/mf2/resource/src/index.ts
@@ -1,1 +1,9 @@
 export { CST, parseCST } from './cst-parser.ts';
+export { buildMessageResourceFromCST } from './mf-from-cst.ts';
+export {
+  MessageGroup,
+  MessageResource,
+  MessageResourceParseError,
+  Messages,
+  parseMessageResource
+} from './mf-parser.ts';

--- a/mf2/resource/src/mf-from-cst.ts
+++ b/mf2/resource/src/mf-from-cst.ts
@@ -1,0 +1,83 @@
+import {
+  MessageFormat,
+  type MessageFormatOptions,
+  MessageSyntaxError
+} from 'messageformat';
+import type { CST } from './cst-parser.ts';
+import type { MessageResource, Messages } from './mf-parser.ts';
+import { MessageResourceParseError, getOrCreateSection } from './mf-parser.ts';
+
+/**
+ * Compile a `CST.Resource` value into a tree of MessageFormat instances.
+ *
+ * @param cst - The previously parsed CST resource
+ * @param options - The options used for each MessageFormat isntance.
+ */
+export function buildMessageResourceFromCST(
+  cst: CST.Resource,
+  options?: MessageFormatOptions
+): MessageResource {
+  let locale = '';
+  let inBody = false;
+  let pos = 0;
+  const messages: Messages = Object.create(null);
+  let section = messages;
+  loop: for (const line of cst) {
+    pos = line.range[0];
+    switch (line.type) {
+      case 'empty-line':
+      case 'comment':
+        break;
+      case 'frontmatter':
+        if (inBody) {
+          const msg = 'Identifier must not start with ---';
+          throw new MessageResourceParseError(pos, msg);
+        }
+        if (!locale) {
+          const msg = 'No locale metadata in resource frontmatter';
+          throw new MessageResourceParseError(pos, msg);
+        }
+        inBody = true;
+        break;
+      case 'metadata':
+        if (!inBody && line.key.value === 'locale') locale = line.value.value;
+        break;
+      case 'section-head':
+        if (!inBody) break loop;
+        section = getOrCreateSection(messages, line.id.value);
+        break;
+      case 'entry':
+        if (!inBody) {
+          break loop;
+        } else {
+          const path = [...line.id.value];
+          const last = path.pop()!;
+          const parent = getOrCreateSection(section, path);
+          const self = (parent[last] ??= {});
+          if ('value' in self) {
+            throw new MessageResourceParseError(pos, 'Message already defined');
+          }
+          try {
+            self.value = new MessageFormat(locale, line.value.value, options);
+          } catch (error) {
+            let parseError;
+            if (error instanceof MessageSyntaxError) {
+              parseError = new MessageResourceParseError(
+                pos + error.start,
+                `Message syntax error: ${error.message}`
+              );
+            } else {
+              parseError = new MessageResourceParseError(pos, String(error));
+            }
+            parseError.cause = error;
+            throw parseError;
+          }
+        }
+    }
+  }
+  if (!inBody) {
+    const msg = 'Missing resource frontmatter';
+    throw new MessageResourceParseError(pos, msg);
+  }
+  return { locale, messages };
+}

--- a/mf2/resource/src/mf-parser.test.ts
+++ b/mf2/resource/src/mf-parser.test.ts
@@ -1,0 +1,294 @@
+import type { ExpectationResult } from '@vitest/expect';
+import { MessageFormat, MessagePart } from 'messageformat';
+import { describe, expect, test } from 'vitest';
+import {
+  MessageResourceParseError,
+  parseMessageResource
+} from './mf-parser.ts';
+import { parseCST } from './cst-parser.ts';
+import { buildMessageResourceFromCST } from './mf-from-cst.ts';
+
+declare module 'vitest' {
+  interface Matchers {
+    messageFormatsAs: (
+      expected:
+        | string
+        | MessagePart<string>[]
+        | {
+            params?: Record<string, unknown>;
+            formatted?: string;
+            parts?: MessagePart<string>[];
+          }
+    ) => ExpectationResult;
+  }
+}
+
+expect.extend({
+  messageFormatsAs(mf, expected) {
+    if (mf instanceof MessageFormat) {
+      let params: Record<string, unknown> | undefined;
+      let formatted: string | undefined;
+      let parts: MessagePart<string>[] | undefined;
+      if (typeof expected === 'string') {
+        formatted = expected;
+      } else if (Array.isArray(expected)) {
+        parts = expected;
+      } else if (expected) {
+        ({ params, formatted, parts } = expected);
+      }
+
+      if (typeof formatted === 'string') {
+        const res = mf.format(params);
+        expect(res).toEqual(formatted);
+      }
+
+      if (parts) {
+        const res = mf.formatToParts(params);
+        expect(res).toEqual(parts);
+      }
+
+      return { pass: true, message: () => 'ok' };
+    }
+    return {
+      pass: false,
+      message: () => `expected ${mf} to be a MessageFormat`,
+      actual: mf
+    };
+  }
+});
+
+const FSI = '\u2068';
+const PDI = '\u2069';
+
+for (const { name, parse } of [
+  { name: 'parseMessageResource', parse: parseMessageResource },
+  {
+    name: 'buildMessageResourceFromCST',
+    parse(src: string) {
+      const cst = parseCST(src, (range, msg) => {
+        throw new MessageResourceParseError(range[0], msg);
+      });
+      return buildMessageResourceFromCST(cst);
+    }
+  }
+]) {
+  describe(name, () => {
+    test('empty string', () => {
+      expect(() => parse('')).toThrow('Missing resource frontmatter');
+    });
+
+    test('missing locale', () => {
+      expect(() => parse('---')).toThrow(
+        'No locale metadata in resource frontmatter'
+      );
+    });
+
+    test('minimal empty resource', () => {
+      const res = parse('@locale und\n---\n');
+      expect(res).toEqual({ locale: 'und', messages: {} });
+    });
+
+    test('minimal non-empty resource', () => {
+      const res = parse('@locale und\n---\nkey = value');
+      expect(res).toEqual({
+        locale: 'und',
+        messages: {
+          key: {
+            value: expect.messageFormatsAs({
+              formatted: 'value',
+              parts: [{ type: 'text', value: 'value' }]
+            })
+          }
+        }
+      });
+    });
+
+    test('comments and empty lines', () => {
+      const res = parse(
+        '\n\n#[foo\\] \n## bar\r\n  \t\n#\n@locale und\n---\n\n\n#[foo\\] \n## bar\r\n  \t\n#\n'
+      );
+      expect(res).toEqual({ locale: 'und', messages: {} });
+    });
+
+    test('frontmatter', () => {
+      const res = parse(
+        '@locale en-ZZ\n@foo value\n  on multiple\n\n\n lines\n---\n'
+      );
+      expect(res).toEqual({ locale: 'en-ZZ', messages: {} });
+    });
+
+    test('one-line entry', () => {
+      const res = parse('@locale und\n---\nfoo = {bar}');
+      expect(res).toEqual({
+        locale: 'und',
+        messages: {
+          foo: {
+            value: expect.messageFormatsAs([
+              { type: 'bidiIsolation', value: FSI },
+              { locale: 'und', type: 'string', value: 'bar' },
+              { type: 'bidiIsolation', value: PDI }
+            ])
+          }
+        }
+      });
+    });
+
+    test('multi-line entry', () => {
+      const res = parse(
+        '@locale und\n---\nfoo = \n  {\n    bar\n  }\nnext=value'
+      );
+      expect(res).toEqual({
+        locale: 'und',
+        messages: {
+          foo: {
+            value: expect.messageFormatsAs([
+              { type: 'bidiIsolation', value: FSI },
+              { locale: 'und', type: 'string', value: 'bar' },
+              { type: 'bidiIsolation', value: PDI }
+            ])
+          },
+          next: {
+            value: expect.messageFormatsAs([{ type: 'text', value: 'value' }])
+          }
+        }
+      });
+    });
+
+    test('multi-line entry with empty lines', () => {
+      const res = parse(
+        '@locale und\n---\nfoo = \n\n  {\n\n    bar\n  }\n\nnext=value'
+      );
+      expect(res).toEqual({
+        locale: 'und',
+        messages: {
+          foo: {
+            value: expect.messageFormatsAs([
+              { type: 'bidiIsolation', value: FSI },
+              { locale: 'und', type: 'string', value: 'bar' },
+              { type: 'bidiIsolation', value: PDI }
+            ])
+          },
+          next: {
+            value: expect.messageFormatsAs([{ type: 'text', value: 'value' }])
+          }
+        }
+      });
+    });
+
+    test('multi-line entry with CRLF terminators', () => {
+      const res = parse(
+        '@locale und\r\n---\r\nfoo = \r\n  {\r\n    bar\r\n  }\r\nnext=value'
+      );
+      expect(res).toEqual({
+        locale: 'und',
+        messages: {
+          foo: {
+            value: expect.messageFormatsAs([
+              { type: 'bidiIsolation', value: FSI },
+              { locale: 'und', type: 'string', value: 'bar' },
+              { type: 'bidiIsolation', value: PDI }
+            ])
+          },
+          next: {
+            value: expect.messageFormatsAs([{ type: 'text', value: 'value' }])
+          }
+        }
+      });
+    });
+
+    test('section-head with trailing whitespace', () => {
+      const res = parse('@locale und\n---\n[ foo . bar ] \t\n');
+      expect(res).toEqual({
+        locale: 'und',
+        messages: { foo: { messages: { bar: { messages: {} } } } }
+      });
+    });
+
+    test('escaped contents', () => {
+      const res = parse(
+        '@locale und\n---\n[f\\xf6o\\r\\n\\ \t.b\\u00E4r\\]\\|\\{]\nlong\\tkey=\\{msg\\|\\nlines\\}\n'
+      );
+      expect(res).toEqual({
+        locale: 'und',
+        messages: {
+          'föo\r\n ': {
+            messages: {
+              'bär]|{': {
+                messages: {
+                  'long\tkey': {
+                    value: expect.messageFormatsAs('{msg|\nlines}')
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    describe('duplicate identifiers', () => {
+      test('top-level entries', () => {
+        expect(() => parse('@locale und\n---\na=1\na=2\n')).toThrow(
+          'Message already defined'
+        );
+      });
+
+      test('identifiers get longer', () => {
+        const res = parse('@locale und\n---\na=1\na.b=2\n[a.b]\nc=3');
+        expect(res).toEqual({
+          locale: 'und',
+          messages: {
+            a: {
+              value: expect.messageFormatsAs('1'),
+              messages: {
+                b: {
+                  value: expect.messageFormatsAs('2'),
+                  messages: { c: { value: expect.messageFormatsAs('3') } }
+                }
+              }
+            }
+          }
+        });
+      });
+
+      test.skip('identifiers get shorter', () => {
+        const res = parse('@locale und\n---\na.b.c=1\na.b=2\na=3\n[a.b]');
+        expect(res).toEqual({
+          locale: 'und',
+          messages: {
+            a: {
+              value: expect.messageFormatsAs('3'),
+              messages: {
+                b: {
+                  value: expect.messageFormatsAs('2'),
+                  messages: { c: { value: expect.messageFormatsAs('1') } }
+                }
+              }
+            }
+          }
+        });
+      });
+    });
+
+    describe('errors', () => {
+      for (const [body, error] of [
+        ['\vkey = foo', 'Invalid entry identifier'],
+        ['[ ]', 'Invalid section identifier'],
+        ['[..]', 'Invalid section identifier'],
+        ['[a b]', 'Invalid section identifier'],
+        ['[a.b] c', 'Invalid section identifier'],
+        ['[a.b] #c', 'Invalid section identifier'],
+        ['key foo', 'Invalid entry identifier'],
+        ['key = foo\u2028bar', 'Invalid entry value'],
+        ['\t# c', 'Invalid indent'],
+        ['a.b = 1\nc = 2\n[a]\nb = 3', 'Message already defined'],
+        ['a = 1\n---b = 2', 'Invalid frontmatter separator'],
+        ['a = 1\n[---b]', 'Invalid frontmatter separator']
+      ]) {
+        test(JSON.stringify(body), () => {
+          expect(() => parse(`@locale und\n---\n${body}`)).toThrow(error);
+        });
+      }
+    });
+  });
+}

--- a/mf2/resource/src/mf-parser.ts
+++ b/mf2/resource/src/mf-parser.ts
@@ -1,0 +1,286 @@
+import { MessageFormat, type MessageFormatOptions } from 'messageformat';
+
+export type MessageResource = {
+  locale: string;
+  messages: Messages;
+};
+
+export type Messages = { [key: string]: MessageGroup };
+
+export type MessageGroup = {
+  value?: MessageFormat;
+  messages?: Messages;
+};
+
+export class MessageResourceParseError extends Error {
+  pos: number;
+  constructor(pos: number, message: string) {
+    super(message);
+    this.pos = pos;
+  }
+}
+
+/** GLOBAL STATE: Current parser position */
+let pos: number;
+
+/** GLOBAL STATE: The full source being parsed */
+let source: string;
+
+/**
+ * Parse input into a tree of MessageFormat instances.
+ *
+ * The frontmatter locale is required;
+ * all other metadata is ignored.
+ *
+ * @param source - The full source being parsed
+ * @param options - The options used for each MessageFormat isntance.
+ */
+export function parseMessageResource(
+  source: string,
+  options?: MessageFormatOptions
+): MessageResource;
+export function parseMessageResource(
+  source_: string,
+  options?: MessageFormatOptions
+): MessageResource {
+  pos = 0;
+  source = source_;
+  const locale = parseFrontmatter();
+  const messages: Messages = Object.create(null);
+  let section = messages;
+  while (pos < source.length) {
+    switch (source[pos]) {
+      case '\t':
+      case '\n':
+      case '\r':
+      case ' ':
+        parseLineEnd('');
+        break;
+      case '#':
+        parseComment();
+        break;
+      case '@':
+        parseMetadata();
+        break;
+      case '[':
+        pos += 1; // '['
+        section = getOrCreateSection(messages, parseId('section'));
+        if (source[pos] !== ']') {
+          const msg = 'Invalid section identifier';
+          throw new MessageResourceParseError(pos, msg);
+        }
+        pos += 1;
+        parseLineEnd('section identifier');
+        break;
+      default: {
+        const start = pos;
+        const path = parseId('entry');
+        const last = path.pop()!;
+        const parent = getOrCreateSection(section, path);
+        const self = (parent[last] ??= {});
+        if ('value' in self) {
+          throw new MessageResourceParseError(start, 'Message already defined');
+        }
+        self.value = parseValue(locale, options);
+        break;
+      }
+    }
+  }
+  return { locale, messages };
+}
+
+export function getOrCreateSection(root: Messages, path: string[]): Messages {
+  let section = root;
+  for (const name of path) {
+    const prev = section[name];
+    if (prev) {
+      section = prev.messages ??= Object.create(null);
+    } else {
+      const messages = Object.create(null);
+      section[name] = { messages };
+      section = messages;
+    }
+  }
+  return section;
+}
+
+const localeMetadata = /^@locale[ \t]+([\w-]+)[ \t]*$/my;
+function parseFrontmatter(): string {
+  let locale = '';
+  loop: while (pos < source.length) {
+    switch (source[pos]) {
+      case '\t':
+      case '\n':
+      case '\r':
+      case ' ':
+        parseLineEnd('');
+        break;
+      case '#':
+        parseComment();
+        break;
+      case '@': {
+        localeMetadata.lastIndex = pos;
+        const m = localeMetadata.exec(source);
+        if (m) {
+          locale = m[1];
+          pos = localeMetadata.lastIndex;
+          parseLineEnd('metadata');
+        } else {
+          parseMetadata();
+        }
+        break;
+      }
+      case '-':
+        if (source.startsWith('---', pos)) {
+          pos += 3; // '---'
+          parseLineEnd('frontmatter separator');
+          if (!locale) {
+            const msg = 'No locale metadata in resource frontmatter';
+            throw new MessageResourceParseError(pos, msg);
+          }
+          return locale;
+        }
+      // fallthrough
+      default:
+        break loop;
+    }
+  }
+  throw new MessageResourceParseError(pos, 'Missing resource frontmatter');
+}
+
+function parseComment() {
+  const lf = source.indexOf('\n', pos + 1);
+  pos = lf === -1 ? source.length : lf + 1;
+}
+
+const metadata = /[ \t].*(?:\r?\n|$)|\r?\n/y;
+function parseMetadata() {
+  parseComment();
+  metadata.lastIndex = pos;
+  while (metadata.exec(source)) pos = metadata.lastIndex;
+}
+
+function parseId(context: string): string[] {
+  const id = [parseIdPart(context, true)];
+  while (source[pos] === '.') {
+    pos += 1;
+    id.push(parseIdPart(context, false));
+  }
+  return id;
+}
+
+const idPart =
+  /[\t ]*((?:[-a-zA-Z0-9_\u{A1}-\u{1FFF}\u{200C}-\u{200D}\u{2030}-\u{205E}\u{2070}-\u{2FEF}\u{3001}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFFD}\u{10000}-\u{EFFFF}]|\\[\t\x20-\x2F\x3A-\x40\x5B-\x60nrt\x7B-\x7E\xA1-\xBF\xD7\xF7\u{2010}-\u{2027}\u{2030}-\u{205E}\u{2190}-\u{2BFF}]|\\x[0-9a-fA-F]{2}|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{6})+)[\t ]*/uy;
+const idEscape = /\\(?:x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{6}|.)/g;
+function parseIdPart(context: string, first: boolean): string {
+  idPart.lastIndex = pos;
+  const m = idPart.exec(source);
+  if (!m) {
+    throw new MessageResourceParseError(pos, `Invalid ${context} identifier`);
+  }
+  const raw = m[1];
+  if (first && raw.startsWith('---')) {
+    throw new MessageResourceParseError(pos, 'Invalid frontmatter separator');
+  }
+  pos = idPart.lastIndex;
+  return raw.replace(idEscape, esc => {
+    switch (esc[1]) {
+      case 'n':
+        return '\n';
+      case 'r':
+        return '\r';
+      case 't':
+        return '\t';
+      case 'u':
+      case 'U':
+      case 'x':
+        return String.fromCharCode(parseInt(esc.substring(2), 16));
+      default:
+        return esc[1];
+    }
+  });
+}
+
+const valueStart = /=[\t ]*/y;
+const valueIndent = /[\t ]+|(?=\r?\n)/y;
+const valueLine =
+  /((?:[\t\x20-\x5B\x5D-\x7E\u{A0}-\u{2027}\u{202A}-\u{D7FF}\u{E000}-\u{10FFFF}]|\\[\t \\{|}nrt]|\\x[0-9a-fA-F]{2}|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{6})*)(?:\r?\n|$)/uy;
+const valueEscape = /\\(?:x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{6}|.)/g;
+function parseValue(
+  locale: string,
+  options: MessageFormatOptions | undefined
+): MessageFormat {
+  valueStart.lastIndex = pos;
+  if (!valueStart.test(source)) {
+    throw new MessageResourceParseError(pos, 'Invalid entry identifier');
+  }
+
+  pos = valueStart.lastIndex;
+
+  valueLine.lastIndex = pos;
+  const m = valueLine.exec(source);
+  if (!m) throw new MessageResourceParseError(pos, 'Invalid entry value');
+  const lines = m[1] ? [m[1]] : [];
+  pos = valueLine.lastIndex;
+
+  while (true) {
+    valueIndent.lastIndex = pos;
+    if (!valueIndent.test(source)) break;
+    valueLine.lastIndex = valueIndent.lastIndex;
+    const m = valueLine.exec(source);
+    if (!m) throw new MessageResourceParseError(pos, 'Invalid entry value');
+    if (lines.length > 0 || m[1]) lines.push(m[1]);
+    pos = valueLine.lastIndex;
+  }
+
+  while (lines.at(-1) === '') lines.pop();
+  const src = lines.join('\n').replace(valueEscape, esc => {
+    switch (esc[1]) {
+      case 'n':
+        return '\n';
+      case 'r':
+        return '\r';
+      case '\t':
+      case 't':
+        return '\t';
+      case ' ':
+        return ' ';
+      case 'u':
+      case 'U':
+      case 'x':
+        return String.fromCharCode(parseInt(esc.substring(2), 16));
+      default:
+        return esc;
+    }
+  });
+  return new MessageFormat(locale, src, options);
+}
+
+/**
+ * id-escape = backslash (escaped / symbols)
+ * value-escape = backslash (escaped / "{" / "|" / "}")
+ *
+ * backslash = "\"
+ * escaped = backslash
+ *         / SP / HTAB
+ *         / %s"n" / %s"r" / %s"t" ; represent LF, CR, HTAB
+ *         / (%s"x" HEXDIG HEXDIG)
+ *         / (%s"u" HEXDIG HEXDIG HEXDIG HEXDIG)
+ *         / (%s"U" HEXDIG HEXDIG HEXDIG HEXDIG HEXDIG HEXDIG)
+ * symbols = %x21-2F / %x3A-40 / %x5B-60 / %x7B-7E ; ASCII symbols and punctuation
+ *         / %xA1-BF / %xD7 / %xF7 ; Latin-1 symbols and punctuation
+ *         / %x2010-2027 / %x2030-205E / %x2190-2BFF ; General symbols and punctuation
+ */
+
+const lineEnd = /[\t ]*\r?\n/y;
+function parseLineEnd(context: string) {
+  lineEnd.lastIndex = pos;
+  if (lineEnd.exec(source)) {
+    pos = lineEnd.lastIndex;
+  } else if (pos < source.length) {
+    const msg = context
+      ? `Invalid ${context}: Unexpected content at line end`
+      : 'Invalid indent';
+    throw new MessageResourceParseError(pos, msg);
+  }
+}


### PR DESCRIPTION
Filing initially as draft, as this relies on an upstream spec change to allow for empty lines within an entry. Also, I'll likely pile on some more related changes to this PR.

Adds the following new functions to the `@messageformat/resource` package:

```ts
/**
 * Parse input into a tree of MessageFormat instances.
 *
 * The frontmatter locale is required;
 * all other metadata is ignored.
 *
 * @param source - The full source being parsed
 * @param options - The options used for each MessageFormat isntance.
 */
export function parseMessageResource(
  source: string,
  options?: MessageFormatOptions
): MessageResource;
```

```ts
/**
 * Compile a `CST.Resource` value into a tree of MessageFormat instances.
 *
 * @param cst - The previously parsed CST resource
 * @param options - The options used for each MessageFormat isntance.
 */
export function buildMessageResourceFromCST(
  cst: CST.Resource,
  options?: MessageFormatOptions
): MessageResource;
```

CC @lucacasonato 